### PR TITLE
Adds demo app for social auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.2] - 2021-10-30
+
+### Added
+- FDI 1.10 support (just changing the frontendDriverInterfaceSupported.json)
+
 ## [3.0.1] - 2021-10-28
 
 ### Changes

--- a/lib/build/version.d.ts
+++ b/lib/build/version.d.ts
@@ -1,2 +1,2 @@
-export declare const package_version = "3.0.1";
+export declare const package_version = "3.0.2";
 export declare const supported_fdi: string[];

--- a/lib/build/version.js
+++ b/lib/build/version.js
@@ -12,5 +12,5 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-export const package_version = "3.0.1";
-export const supported_fdi = ["1.8", "1.9"];
+export const package_version = "3.0.2";
+export const supported_fdi = ["1.8", "1.9", "1.10"];

--- a/lib/ts/version.ts
+++ b/lib/ts/version.ts
@@ -12,6 +12,6 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-export const package_version = "3.0.1";
+export const package_version = "3.0.2";
 
-export const supported_fdi = ["1.8", "1.9"];
+export const supported_fdi = ["1.8", "1.9", "1.10"];

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "supertokens-react-native",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "supertokens-react-native",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "React Native SDK for SuperTokens",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Summary of change
Adds a demo app that explains how to use social auth using:
- Google
- Github
- Apple

with SuperTokens

## Documentation changes
WIP

## Checklist for important updates
- [ ] Changelog has been updated
- [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
   - Along with the associated array in `lib/ts/version.ts`
- [ ] Changes to the version if needed
   - In `package.json`
   - In `package-lock.json`
   - In `lib/ts/version.ts`
- [x] Had run `npm run build-pretty`
- [x] Had installed and ran the pre-commit hook
- [x] Issue this PR against the latest non released version branch.
   - To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
   - If no such branch exists, then create one from the latest released branch.

## Remaining TODOs for this PR
- [ ] Sign in with facebook