### PR TITLE
chore: Modify test job in CICD to retry test suite if it fails

### DIFF
--- a/.circleci/doTests.sh
+++ b/.circleci/doTests.sh
@@ -82,15 +82,32 @@ while [ $i -lt $frontendDriverLength ]; do
     coreFree=$(echo $coreFree | jq .core | tr -d '"')
 
     someTestsRan=true
-    ./setupAndTestWithFreeCore.sh $coreFree $driverTag $version
-    if [[ $? -ne 0 ]]
-    then
-        echo "test failed... exiting!"
-        exit 1
-    fi
-    rm -rf ../../supertokens-root
-    rm -rf ../TestingApp/test/server/node_modules/supertokens-node
-    git checkout HEAD -- ../TestingApp/test/server/package.json
+    tries=1
+
+    while [ $tries -le 3 ]
+    do
+        tries=$(( $tries + 1 ))
+        ./setupAndTestWithFreeCore.sh $coreFree $driverTag $version
+
+        if [[ $? -ne 0 ]]
+        then
+            if [[ $tries -le 3 ]]
+            then
+                rm -rf ../../supertokens-root
+                rm -rf ../TestingApp/test/server/node_modules/supertokens-node
+                git checkout HEAD -- ../TestingApp/test/server/package.json
+                echo "test failed... retrying!"
+            else
+                echo "test failed... exiting!"
+                exit 1
+            fi
+        else
+            rm -rf ../../supertokens-root
+            rm -rf ../TestingApp/test/server/node_modules/supertokens-node
+            git checkout HEAD -- ../TestingApp/test/server/package.json
+            break
+        fi
+    done
 done
 
 if [[ $someTestsRan = "true" ]]


### PR DESCRIPTION
## Summary of change

The test suite sometimes fails intermittently on CICD (triggering the job again results in the tests passing), this is problematic sometimes. To solve this we make the circle ci script retry on test failure (downside is that in actual failure the test will still run 3 times which takes longer)

## Related issues
- https://github.com/supertokens/supertokens-react-native/issues/50

## Test Plan
No code change made in this PR

## Documentation changes
None required

## Checklist for important updates
- [ ] ~~Changelog has been updated~~
- [ ] ~~`frontendDriverInterfaceSupported.json` file has been updated (if needed)~~
   - ~~Along with the associated array in `lib/ts/version.ts`~~
- [ ] ~~Changes to the version if needed~~
   - ~~In `package.json`~~
   - ~~In `package-lock.json`~~
   - ~~In `lib/ts/version.ts`~~
- [x] Had run `npm run build-pretty`
- [x] Had installed and ran the pre-commit hook
- [x] Issue this PR against the latest non released version branch.
   - To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
   - If no such branch exists, then create one from the latest released branch.

## Remaining TODOs for this PR
- [ ] Verify if a version update is required