### PR TITLE
chore: Add dashboard init to example app server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+### Changes
+
+- Adds dashboard to the with-thirdpartyemailpassword example app server
+
 ## [4.0.0] - 2023-01-30
 
 ### Breaking Changes

--- a/examples/with-thirdpartyemailpassword/package.json
+++ b/examples/with-thirdpartyemailpassword/package.json
@@ -13,6 +13,7 @@
     "@invertase/react-native-apple-authentication": "^2.1.5",
     "react": "17.0.2",
     "react-native": "0.66.1",
+    "supertokens-node": "^13.1.5",
     "supertokens-react-native": "^4.0.0"
   },
   "devDependencies": {
@@ -27,8 +28,7 @@
     "jest": "^26.6.3",
     "metro-react-native-babel-preset": "^0.66.2",
     "react-native-app-auth": "^6.4.0",
-    "react-test-renderer": "17.0.2",
-    "supertokens-node": "^13.0.2"
+    "react-test-renderer": "17.0.2"
   },
   "jest": {
     "preset": "react-native"

--- a/examples/with-thirdpartyemailpassword/server/index.js
+++ b/examples/with-thirdpartyemailpassword/server/index.js
@@ -2,6 +2,7 @@ let express = require("express");
 let supertokens = require("supertokens-node");
 let Session = require("supertokens-node/recipe/session");
 let ThirdPartyEmailPassword = require("supertokens-node/recipe/thirdpartyemailpassword");
+let Dashboard = require("supertokens-node/recipe/dashboard");
 let { Google, Github } = ThirdPartyEmailPassword;
 let cors = require("cors");
 let { middleware } = require("supertokens-node/framework/express");
@@ -76,7 +77,8 @@ supertokens.init({
                 })
             ]
         }),
-        Session.init() // initializes session features
+        Session.init(), // initializes session features
+        Dashboard.init()
     ]
 });
 


### PR DESCRIPTION
## Summary of change
- Updates the version of supertokens-node for the example app
- Adds dashboard init to the example app backend

## Related issues
- 

## Test Plan
NA

## Documentation changes
NA

## Checklist for important updates
- [x] Changelog has been updated
- [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
   - Along with the associated array in `lib/ts/version.ts`
- [ ] Changes to the version if needed
   - In `package.json`
   - In `package-lock.json`
   - In `lib/ts/version.ts`
- [x] Had run `npm run build-pretty`
- [x] Had installed and ran the pre-commit hook
- [x] Issue this PR against the latest non released version branch.
   - To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
   - If no such branch exists, then create one from the latest released branch.

## Remaining TODOs for this PR
- [ ] ...