### PR TITLE
refactor: Add init check to functions exposed by the SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [4.0.2] - 2023-05-22
+
+- Adds a check to make sure `SuperTokens.init` is called when using functions exposed by the SDK
+
 ## [4.0.1] - 2023-05-03
 
 - Adds tests based on changes in the session management logic in the backend SDKs and SuperTokens core

--- a/lib/build/index.js
+++ b/lib/build/index.js
@@ -54,10 +54,16 @@ export default class AuthHttpRequest {
         AuthHttpRequest.axiosInterceptorQueue = [];
     }
     static getUserId() {
+        if (!AuthHttpRequestFetch.initCalled) {
+            throw Error("init function not called");
+        }
         return AuthHttpRequestFetch.recipeImpl.getUserId(AuthHttpRequestFetch.config);
     }
     static getAccessTokenPayloadSecurely() {
         return __awaiter(this, void 0, void 0, function*() {
+            if (!AuthHttpRequestFetch.initCalled) {
+                throw Error("init function not called");
+            }
             return AuthHttpRequestFetch.recipeImpl.getAccessTokenPayloadSecurely(AuthHttpRequestFetch.config);
         });
     }
@@ -68,6 +74,9 @@ AuthHttpRequest.attemptRefreshingSession = () =>
         return AuthHttpRequestFetch.attemptRefreshingSession();
     });
 AuthHttpRequest.doesSessionExist = () => {
+    if (!AuthHttpRequestFetch.initCalled) {
+        throw Error("init function not called");
+    }
     return AuthHttpRequestFetch.recipeImpl.doesSessionExist(AuthHttpRequestFetch.config);
 };
 AuthHttpRequest.addAxiosInterceptors = axiosInstance => {
@@ -83,10 +92,16 @@ AuthHttpRequest.addAxiosInterceptors = axiosInstance => {
     }
 };
 AuthHttpRequest.signOut = () => {
+    if (!AuthHttpRequestFetch.initCalled) {
+        throw Error("init function not called");
+    }
     return AuthHttpRequestFetch.recipeImpl.signOut(AuthHttpRequestFetch.config);
 };
 AuthHttpRequest.getAccessToken = () =>
     __awaiter(void 0, void 0, void 0, function*() {
+        if (!AuthHttpRequestFetch.initCalled) {
+            throw Error("init function not called");
+        }
         // This takes care of refreshing the access token if needed
         if (yield AuthHttpRequestFetch.recipeImpl.doesSessionExist(AuthHttpRequestFetch.config)) {
             return getTokenForHeaderAuth("access");

--- a/lib/build/version.d.ts
+++ b/lib/build/version.d.ts
@@ -1,2 +1,2 @@
-export declare const package_version = "4.0.1";
+export declare const package_version = "4.0.2";
 export declare const supported_fdi: string[];

--- a/lib/build/version.js
+++ b/lib/build/version.js
@@ -12,5 +12,5 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-export const package_version = "4.0.1";
+export const package_version = "4.0.2";
 export const supported_fdi = ["1.16"];

--- a/lib/ts/index.ts
+++ b/lib/ts/index.ts
@@ -29,10 +29,18 @@ export default class AuthHttpRequest {
     }
 
     static getUserId(): Promise<string> {
+        if (!AuthHttpRequestFetch.initCalled) {
+            throw Error("init function not called");
+        }
+
         return AuthHttpRequestFetch.recipeImpl.getUserId(AuthHttpRequestFetch.config);
     }
 
     static async getAccessTokenPayloadSecurely(): Promise<any> {
+        if (!AuthHttpRequestFetch.initCalled) {
+            throw Error("init function not called");
+        }
+
         return AuthHttpRequestFetch.recipeImpl.getAccessTokenPayloadSecurely(AuthHttpRequestFetch.config);
     }
 
@@ -41,6 +49,10 @@ export default class AuthHttpRequest {
     };
 
     static doesSessionExist = () => {
+        if (!AuthHttpRequestFetch.initCalled) {
+            throw Error("init function not called");
+        }
+
         return AuthHttpRequestFetch.recipeImpl.doesSessionExist(AuthHttpRequestFetch.config);
     };
 
@@ -58,10 +70,18 @@ export default class AuthHttpRequest {
     };
 
     static signOut = () => {
+        if (!AuthHttpRequestFetch.initCalled) {
+            throw Error("init function not called");
+        }
+
         return AuthHttpRequestFetch.recipeImpl.signOut(AuthHttpRequestFetch.config);
     };
 
     static getAccessToken = async (): Promise<string | undefined> => {
+        if (!AuthHttpRequestFetch.initCalled) {
+            throw Error("init function not called");
+        }
+
         // This takes care of refreshing the access token if needed
         if (await AuthHttpRequestFetch.recipeImpl.doesSessionExist(AuthHttpRequestFetch.config)) {
             return getTokenForHeaderAuth("access");

--- a/lib/ts/version.ts
+++ b/lib/ts/version.ts
@@ -12,6 +12,6 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-export const package_version = "4.0.1";
+export const package_version = "4.0.2";
 
 export const supported_fdi = ["1.16"];

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "supertokens-react-native",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "supertokens-react-native",
-      "version": "4.0.1",
+      "version": "4.0.2",
       "license": "Apache 2.0",
       "dependencies": {
         "base-64": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "supertokens-react-native",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "description": "React Native SDK for SuperTokens",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Summary of change
- Adds an init check in functions exposed by the index file to make sure `recipeImpl` is not used before the SDK is initialised

## Related issues
- 

## Test Plan

## Documentation changes
NA

## Checklist for important updates
- [x] Changelog has been updated
- [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
   - Along with the associated array in `lib/ts/version.ts`
- [x] Changes to the version if needed
   - In `package.json`
   - In `package-lock.json`
   - In `lib/ts/version.ts`
- [x] Had run `npm run build-pretty`
- [x] Had installed and ran the pre-commit hook
- [x] Issue this PR against the latest non released version branch.
   - To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
   - If no such branch exists, then create one from the latest released branch.

## Remaining TODOs for this PR
- [ ] ...