### PR TITLE
refactor: Allow users to disable interception and fix interception logic for auth headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [4.0.4] - 2023-07-06
+
+### Changes
+
+- Added `shouldDoInterceptionBasedOnUrl` as an overrideable function to the recipe interface
+
+### Fixes
+
+- Fixed an issue where the Authorization header was getting removed unnecessarily
+
 ## [4.0.3] - 2023-06-06
 
 - Refactors session logic to delete access token and refresh token if the front token is removed. This helps with proxies that strip headers with empty values which would result in the access token and refresh token to persist after signout

--- a/TestingApp/test/axios2.spec.js
+++ b/TestingApp/test/axios2.spec.js
@@ -297,4 +297,33 @@ describe("Axios AuthHttpRequest class tests", function() {
 
         assert(idRefreshInCookies.length === 0);
     });
+
+    it("test that interception happens based on the return value of shouldDoInterceptionBasedOnUrl override", async function() {
+        await startST();
+        AuthHttpRequest.addAxiosInterceptors(axiosInstance);
+        AuthHttpRequest.init({
+            apiDomain: BASE_URL,
+            tokenTransferMethod: "cookie",
+            override: {
+                functions: oI => {
+                    return {
+                        ...oI,
+                        shouldDoInterceptionBasedOnUrl: url => {
+                            if (url.includes("doOverride")) {
+                                return true;
+                            }
+
+                            return false;
+                        }
+                    };
+                }
+            }
+        });
+
+        let response = await axiosInstance.get(`${BASE_URL}/check-rid-no-session`);
+        assertEqual(response.data, "fail");
+
+        let response2 = await axiosInstance.get(`${BASE_URL}/check-rid-no-session?doOverride`);
+        assertEqual(response2.data, "success");
+    });
 });

--- a/TestingApp/test/config.spec.js
+++ b/TestingApp/test/config.spec.js
@@ -42,6 +42,13 @@ describe("Config tests", function() {
     });
 
     it("testing shouldDoInterceptionBasedOnUrl", async function() {
+        AuthHttpRequest.init({
+            apiDomain: "example.com",
+            apiBasePath: "/"
+        });
+        const shouldDoInterceptionBasedOnUrl = AuthHttpRequestFetch.recipeImpl.shouldDoInterceptionBasedOnUrl.bind(
+            AuthHttpRequestFetch.recipeImpl
+        );
         // true cases without cookieDomain
         assert(shouldDoInterceptionBasedOnUrl("api.example.com", "https://api.example.com", undefined));
         assert(shouldDoInterceptionBasedOnUrl("http://api.example.com", "http://api.example.com", undefined));

--- a/TestingApp/test/fetch.spec.js
+++ b/TestingApp/test/fetch.spec.js
@@ -1553,4 +1553,32 @@ describe("Fetch AuthHttpRequest class tests", function() {
             done(err);
         }
     });
+
+    it("test that interception happens based on the return value of shouldDoInterceptionBasedOnUrl override", async function() {
+        await startST();
+        AuthHttpRequest.init({
+            apiDomain: BASE_URL,
+            tokenTransferMethod: "cookie",
+            override: {
+                functions: oI => {
+                    return {
+                        ...oI,
+                        shouldDoInterceptionBasedOnUrl: url => {
+                            if (url.includes("doOverride")) {
+                                return true;
+                            }
+
+                            return false;
+                        }
+                    };
+                }
+            }
+        });
+
+        let response = await global.fetch(`${BASE_URL}/check-rid-no-session`);
+        assertEqual(await response.text(), "fail");
+
+        let response2 = await global.fetch(`${BASE_URL}/check-rid-no-session?doOverride`);
+        assertEqual(await response2.text(), "success");
+    });
 });

--- a/TestingApp/test/server/index.js
+++ b/TestingApp/test/server/index.js
@@ -312,6 +312,11 @@ app.get(
     }
 );
 
+app.get("/check-rid-no-session", async (req, res) => {
+    let rid = req.headers["rid"];
+    res.send(!rid || !rid.startsWith("anti-csrf") ? "fail" : "success");
+});
+
 app.get(
     "/update-jwt",
     (req, res, next) => verifySession()(req, res, next),

--- a/lib/build/axios.js
+++ b/lib/build/axios.js
@@ -34,13 +34,7 @@ import AuthHttpRequestFetch, { onUnauthorisedResponse } from "./fetch";
 import FrontToken from "./frontToken";
 import AntiCSRF from "./antiCsrf";
 import { PROCESS_STATE, ProcessState } from "./processState";
-import {
-    fireSessionUpdateEventsIfNecessary,
-    getLocalSessionState,
-    getTokenForHeaderAuth,
-    setToken,
-    shouldDoInterceptionBasedOnUrl
-} from "./utils";
+import { fireSessionUpdateEventsIfNecessary, getLocalSessionState, getTokenForHeaderAuth, setToken } from "./utils";
 function getUrlFromConfig(config) {
     let url = config.url === undefined ? "" : config.url;
     let baseURL = config.baseURL;
@@ -62,7 +56,7 @@ export function interceptorFunctionRequestFulfilled(config) {
         try {
             doNotDoInterception =
                 typeof url === "string" &&
-                !shouldDoInterceptionBasedOnUrl(
+                !AuthHttpRequestFetch.recipeImpl.shouldDoInterceptionBasedOnUrl(
                     url,
                     AuthHttpRequestFetch.config.apiDomain,
                     AuthHttpRequestFetch.config.sessionTokenBackendDomain
@@ -125,7 +119,7 @@ export function responseInterceptor(axiosInstance) {
                 try {
                     doNotDoInterception =
                         typeof url === "string" &&
-                        !shouldDoInterceptionBasedOnUrl(
+                        !AuthHttpRequestFetch.recipeImpl.shouldDoInterceptionBasedOnUrl(
                             url,
                             AuthHttpRequestFetch.config.apiDomain,
                             AuthHttpRequestFetch.config.sessionTokenBackendDomain
@@ -217,7 +211,7 @@ AuthHttpRequest.doRequest = (httpCall, config, url, prevResponse, prevError, via
         try {
             doNotDoInterception =
                 typeof url === "string" &&
-                !shouldDoInterceptionBasedOnUrl(
+                !AuthHttpRequestFetch.recipeImpl.shouldDoInterceptionBasedOnUrl(
                     url,
                     AuthHttpRequestFetch.config.apiDomain,
                     AuthHttpRequestFetch.config.sessionTokenBackendDomain

--- a/lib/build/axios.js
+++ b/lib/build/axios.js
@@ -401,8 +401,9 @@ function setAuthorizationHeaderIfRequired(requestConfig) {
 function removeAuthHeaderIfMatchesLocalToken(config) {
     return __awaiter(this, void 0, void 0, function*() {
         const accessToken = yield getTokenForHeaderAuth("access");
+        const refreshToken = yield getTokenForHeaderAuth("refresh");
         const authHeader = config.headers.Authorization || config.headers.authorization;
-        if (accessToken !== undefined) {
+        if (accessToken !== undefined && refreshToken !== undefined) {
             if (authHeader === `Bearer ${accessToken}`) {
                 // We are ignoring the Authorization header set by the user in this case, because it would cause issues
                 // If we do not ignore this, then this header would be used even if the request is being retried after a refresh, even though it contains an outdated access token.

--- a/lib/build/fetch.js
+++ b/lib/build/fetch.js
@@ -132,7 +132,12 @@ AuthHttpRequest.doRequest = (httpCall, config, url) =>
         );
         if (originalHeaders.has("Authorization")) {
             const accessToken = yield getTokenForHeaderAuth("access");
-            if (accessToken !== undefined && originalHeaders.get("Authorization") === `Bearer ${accessToken}`) {
+            const refreshToken = yield getTokenForHeaderAuth("refresh");
+            if (
+                accessToken !== undefined &&
+                refreshToken !== undefined &&
+                originalHeaders.get("Authorization") === `Bearer ${accessToken}`
+            ) {
                 // We are ignoring the Authorization header set by the user in this case, because it would cause issues
                 // If we do not ignore this, then this header would be used even if the request is being retried after a refresh, even though it contains an outdated access token.
                 // This causes an infinite refresh loop.

--- a/lib/build/fetch.js
+++ b/lib/build/fetch.js
@@ -52,7 +52,6 @@ import {
     getLocalSessionState,
     getTokenForHeaderAuth,
     setToken,
-    shouldDoInterceptionBasedOnUrl,
     validateAndNormaliseInputOrThrowError
 } from "./utils";
 import FrontToken from "./frontToken";
@@ -107,14 +106,14 @@ AuthHttpRequest.doRequest = (httpCall, config, url) =>
         try {
             doNotDoInterception =
                 (typeof url === "string" &&
-                    !shouldDoInterceptionBasedOnUrl(
+                    !AuthHttpRequest.recipeImpl.shouldDoInterceptionBasedOnUrl(
                         url,
                         AuthHttpRequest.config.apiDomain,
                         AuthHttpRequest.config.sessionTokenBackendDomain
                     )) ||
                 (url !== undefined &&
                 typeof url.url === "string" && // this is because url can be an object like {method: ..., url: ...}
-                    !shouldDoInterceptionBasedOnUrl(
+                    !AuthHttpRequest.recipeImpl.shouldDoInterceptionBasedOnUrl(
                         url.url,
                         AuthHttpRequest.config.apiDomain,
                         AuthHttpRequest.config.sessionTokenBackendDomain

--- a/lib/build/recipeImplementation.js
+++ b/lib/build/recipeImplementation.js
@@ -34,7 +34,7 @@ import FrontToken from "./frontToken";
 import { supported_fdi } from "./version";
 import { interceptorFunctionRequestFulfilled, responseErrorInterceptor, responseInterceptor } from "./axios";
 import { SuperTokensGeneralError } from "./error";
-import { getLocalSessionState } from "./utils";
+import { getLocalSessionState, normaliseCookieDomainOrThrowError, normaliseURLDomainOrThrowError } from "./utils";
 export default function RecipeImplementation() {
     return {
         addFetchInterceptorsAndReturnModifiedFetch: function(originalFetch, _) {
@@ -145,6 +145,42 @@ export default function RecipeImplementation() {
                 }
                 // we do not send an event here since it's triggered in fireSessionUpdateEventsIfNecessary.
             });
+        },
+        shouldDoInterceptionBasedOnUrl: (toCheckUrl, apiDomain, sessionTokenBackendDomain) => {
+            function isNumeric(str) {
+                if (typeof str != "string") return false; // we only process strings!
+                return (
+                    !isNaN(str) && !isNaN(parseFloat(str)) // use type coercion to parse the _entirety_ of the string (`parseFloat` alone does not do this)...
+                ); // ...and ensure strings of whitespace fail
+            }
+            toCheckUrl = normaliseURLDomainOrThrowError(toCheckUrl);
+            // @ts-ignore (Typescript complains that URL does not expect a parameter in constructor even though it does for react-native-url-polyfill)
+            let urlObj = new URL(toCheckUrl);
+            let domain = urlObj.hostname;
+            if (sessionTokenBackendDomain === undefined) {
+                domain = urlObj.port === "" ? domain : domain + ":" + urlObj.port;
+                apiDomain = normaliseURLDomainOrThrowError(apiDomain);
+                // @ts-ignore (Typescript complains that URL does not expect a parameter in constructor even though it does for react-native-url-polyfill)
+                let apiUrlObj = new URL(apiDomain);
+                return (
+                    domain === (apiUrlObj.port === "" ? apiUrlObj.hostname : apiUrlObj.hostname + ":" + apiUrlObj.port)
+                );
+            } else {
+                let normalisedSessionDomain = normaliseCookieDomainOrThrowError(sessionTokenBackendDomain);
+                if (sessionTokenBackendDomain.split(":").length > 1) {
+                    // this means that a port may have been provided
+                    let portStr = sessionTokenBackendDomain.split(":")[sessionTokenBackendDomain.split(":").length - 1];
+                    if (isNumeric(portStr)) {
+                        normalisedSessionDomain += ":" + portStr;
+                        domain = urlObj.port === "" ? domain : domain + ":" + urlObj.port;
+                    }
+                }
+                if (sessionTokenBackendDomain.startsWith(".")) {
+                    return ("." + domain).endsWith(normalisedSessionDomain);
+                } else {
+                    return domain === normalisedSessionDomain;
+                }
+            }
         }
     };
 }

--- a/lib/build/types.d.ts
+++ b/lib/build/types.d.ts
@@ -60,6 +60,7 @@ export declare type RecipeInterface = {
     getAccessTokenPayloadSecurely: (config: NormalisedInputType) => Promise<any>;
     doesSessionExist: (config: NormalisedInputType) => Promise<boolean>;
     signOut: (config: NormalisedInputType) => Promise<void>;
+    shouldDoInterceptionBasedOnUrl(toCheckUrl: string, apiDomain: string, sessionTokenBackendDomain: string | undefined): boolean;
 };
 export declare type IdRefreshTokenType = {
     status: "NOT_EXISTS" | "MAY_EXIST";

--- a/lib/build/utils.d.ts
+++ b/lib/build/utils.d.ts
@@ -4,7 +4,6 @@ export declare function normaliseURLDomainOrThrowError(input: string): string;
 export declare function normaliseURLPathOrThrowError(input: string): string;
 export declare function normaliseCookieDomainOrThrowError(cookieDomain: string): string;
 export declare function validateAndNormaliseInputOrThrowError(options: InputType): NormalisedInputType;
-export declare function shouldDoInterceptionBasedOnUrl(toCheckUrl: string, apiDomain: string, sessionTokenBackendDomain: string | undefined): boolean;
 export declare function setToken(tokenType: TokenType, value: string): Promise<void>;
 export declare function storeInStorage(name: string, value: string, expiry: number): Promise<void>;
 /**

--- a/lib/build/utils.js
+++ b/lib/build/utils.js
@@ -130,40 +130,6 @@ export function validateAndNormaliseInputOrThrowError(options) {
         override
     };
 }
-export function shouldDoInterceptionBasedOnUrl(toCheckUrl, apiDomain, sessionTokenBackendDomain) {
-    function isNumeric(str) {
-        if (typeof str != "string") return false; // we only process strings!
-        return (
-            !isNaN(str) && !isNaN(parseFloat(str)) // use type coercion to parse the _entirety_ of the string (`parseFloat` alone does not do this)...
-        ); // ...and ensure strings of whitespace fail
-    }
-    toCheckUrl = normaliseURLDomainOrThrowError(toCheckUrl);
-    // @ts-ignore (Typescript complains that URL does not expect a parameter in constructor even though it does for react-native-url-polyfill)
-    let urlObj = new URL(toCheckUrl);
-    let domain = urlObj.hostname;
-    if (sessionTokenBackendDomain === undefined) {
-        domain = urlObj.port === "" ? domain : domain + ":" + urlObj.port;
-        apiDomain = normaliseURLDomainOrThrowError(apiDomain);
-        // @ts-ignore (Typescript complains that URL does not expect a parameter in constructor even though it does for react-native-url-polyfill)
-        let apiUrlObj = new URL(apiDomain);
-        return domain === (apiUrlObj.port === "" ? apiUrlObj.hostname : apiUrlObj.hostname + ":" + apiUrlObj.port);
-    } else {
-        let normalisedSessionDomain = normaliseCookieDomainOrThrowError(sessionTokenBackendDomain);
-        if (sessionTokenBackendDomain.split(":").length > 1) {
-            // this means that a port may have been provided
-            let portStr = sessionTokenBackendDomain.split(":")[sessionTokenBackendDomain.split(":").length - 1];
-            if (isNumeric(portStr)) {
-                normalisedSessionDomain += ":" + portStr;
-                domain = urlObj.port === "" ? domain : domain + ":" + urlObj.port;
-            }
-        }
-        if (sessionTokenBackendDomain.startsWith(".")) {
-            return ("." + domain).endsWith(normalisedSessionDomain);
-        } else {
-            return domain === normalisedSessionDomain;
-        }
-    }
-}
 export function setToken(tokenType, value) {
     const name = getStorageNameForToken(tokenType);
     // We save the tokens with a 100-year expiration time

--- a/lib/build/version.d.ts
+++ b/lib/build/version.d.ts
@@ -1,2 +1,2 @@
-export declare const package_version = "4.0.3";
+export declare const package_version = "4.0.4";
 export declare const supported_fdi: string[];

--- a/lib/build/version.js
+++ b/lib/build/version.js
@@ -12,5 +12,5 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-export const package_version = "4.0.3";
+export const package_version = "4.0.4";
 export const supported_fdi = ["1.16"];

--- a/lib/ts/axios.ts
+++ b/lib/ts/axios.ts
@@ -20,13 +20,7 @@ import AuthHttpRequestFetch, { onUnauthorisedResponse } from "./fetch";
 import FrontToken from "./frontToken";
 import AntiCSRF from "./antiCsrf";
 import { PROCESS_STATE, ProcessState } from "./processState";
-import {
-    fireSessionUpdateEventsIfNecessary,
-    getLocalSessionState,
-    getTokenForHeaderAuth,
-    setToken,
-    shouldDoInterceptionBasedOnUrl
-} from "./utils";
+import { fireSessionUpdateEventsIfNecessary, getLocalSessionState, getTokenForHeaderAuth, setToken } from "./utils";
 
 function getUrlFromConfig(config: AxiosRequestConfig) {
     let url: string = config.url === undefined ? "" : config.url;
@@ -51,7 +45,7 @@ export async function interceptorFunctionRequestFulfilled(config: AxiosRequestCo
     try {
         doNotDoInterception =
             typeof url === "string" &&
-            !shouldDoInterceptionBasedOnUrl(
+            !AuthHttpRequestFetch.recipeImpl.shouldDoInterceptionBasedOnUrl(
                 url,
                 AuthHttpRequestFetch.config.apiDomain,
                 AuthHttpRequestFetch.config.sessionTokenBackendDomain
@@ -133,7 +127,7 @@ export function responseInterceptor(axiosInstance: any) {
             try {
                 doNotDoInterception =
                     typeof url === "string" &&
-                    !shouldDoInterceptionBasedOnUrl(
+                    !AuthHttpRequestFetch.recipeImpl.shouldDoInterceptionBasedOnUrl(
                         url,
                         AuthHttpRequestFetch.config.apiDomain,
                         AuthHttpRequestFetch.config.sessionTokenBackendDomain
@@ -239,7 +233,7 @@ export default class AuthHttpRequest {
         try {
             doNotDoInterception =
                 typeof url === "string" &&
-                !shouldDoInterceptionBasedOnUrl(
+                !AuthHttpRequestFetch.recipeImpl.shouldDoInterceptionBasedOnUrl(
                     url,
                     AuthHttpRequestFetch.config.apiDomain,
                     AuthHttpRequestFetch.config.sessionTokenBackendDomain

--- a/lib/ts/axios.ts
+++ b/lib/ts/axios.ts
@@ -451,9 +451,10 @@ async function setAuthorizationHeaderIfRequired(requestConfig: AxiosRequestConfi
 
 async function removeAuthHeaderIfMatchesLocalToken(config: AxiosRequestConfig) {
     const accessToken = await getTokenForHeaderAuth("access");
+    const refreshToken = await getTokenForHeaderAuth("refresh");
     const authHeader = config.headers!.Authorization || config.headers!.authorization;
 
-    if (accessToken !== undefined) {
+    if (accessToken !== undefined && refreshToken !== undefined) {
         if (authHeader === `Bearer ${accessToken}`) {
             // We are ignoring the Authorization header set by the user in this case, because it would cause issues
             // If we do not ignore this, then this header would be used even if the request is being retried after a refresh, even though it contains an outdated access token.

--- a/lib/ts/fetch.ts
+++ b/lib/ts/fetch.ts
@@ -24,7 +24,6 @@ import {
     getTokenForHeaderAuth,
     LocalSessionState,
     setToken,
-    shouldDoInterceptionBasedOnUrl,
     validateAndNormaliseInputOrThrowError
 } from "./utils";
 import FrontToken from "./frontToken";
@@ -97,14 +96,14 @@ export default class AuthHttpRequest {
         try {
             doNotDoInterception =
                 (typeof url === "string" &&
-                    !shouldDoInterceptionBasedOnUrl(
+                    !AuthHttpRequest.recipeImpl.shouldDoInterceptionBasedOnUrl(
                         url,
                         AuthHttpRequest.config.apiDomain,
                         AuthHttpRequest.config.sessionTokenBackendDomain
                     )) ||
                 (url !== undefined &&
                 typeof url.url === "string" && // this is because url can be an object like {method: ..., url: ...}
-                    !shouldDoInterceptionBasedOnUrl(
+                    !AuthHttpRequest.recipeImpl.shouldDoInterceptionBasedOnUrl(
                         url.url,
                         AuthHttpRequest.config.apiDomain,
                         AuthHttpRequest.config.sessionTokenBackendDomain

--- a/lib/ts/fetch.ts
+++ b/lib/ts/fetch.ts
@@ -125,8 +125,13 @@ export default class AuthHttpRequest {
 
         if (originalHeaders.has("Authorization")) {
             const accessToken = await getTokenForHeaderAuth("access");
+            const refreshToken = await getTokenForHeaderAuth("refresh");
 
-            if (accessToken !== undefined && originalHeaders.get("Authorization") === `Bearer ${accessToken}`) {
+            if (
+                accessToken !== undefined &&
+                refreshToken !== undefined &&
+                originalHeaders.get("Authorization") === `Bearer ${accessToken}`
+            ) {
                 // We are ignoring the Authorization header set by the user in this case, because it would cause issues
                 // If we do not ignore this, then this header would be used even if the request is being retried after a refresh, even though it contains an outdated access token.
                 // This causes an infinite refresh loop.

--- a/lib/ts/types.ts
+++ b/lib/ts/types.ts
@@ -85,6 +85,12 @@ export type RecipeInterface = {
     doesSessionExist: (config: NormalisedInputType) => Promise<boolean>;
 
     signOut: (config: NormalisedInputType) => Promise<void>;
+
+    shouldDoInterceptionBasedOnUrl(
+        toCheckUrl: string,
+        apiDomain: string,
+        sessionTokenBackendDomain: string | undefined
+    ): boolean;
 };
 
 export type IdRefreshTokenType =

--- a/lib/ts/utils.ts
+++ b/lib/ts/utils.ts
@@ -1,6 +1,5 @@
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import { URL } from "react-native-url-polyfill";
-import AntiCSRF from "./antiCsrf";
 import AuthHttpRequest from "./fetch";
 import FrontToken from "./frontToken";
 import NormalisedURLDomain from "./normalisedURLDomain";
@@ -133,45 +132,6 @@ export function validateAndNormaliseInputOrThrowError(options: InputType): Norma
         onHandleEvent,
         override
     };
-}
-
-export function shouldDoInterceptionBasedOnUrl(
-    toCheckUrl: string,
-    apiDomain: string,
-    sessionTokenBackendDomain: string | undefined
-): boolean {
-    function isNumeric(str: any) {
-        if (typeof str != "string") return false; // we only process strings!
-        return (
-            !isNaN(str as any) && !isNaN(parseFloat(str)) // use type coercion to parse the _entirety_ of the string (`parseFloat` alone does not do this)...
-        ); // ...and ensure strings of whitespace fail
-    }
-    toCheckUrl = normaliseURLDomainOrThrowError(toCheckUrl);
-    // @ts-ignore (Typescript complains that URL does not expect a parameter in constructor even though it does for react-native-url-polyfill)
-    let urlObj: any = new URL(toCheckUrl);
-    let domain = urlObj.hostname;
-    if (sessionTokenBackendDomain === undefined) {
-        domain = urlObj.port === "" ? domain : domain + ":" + urlObj.port;
-        apiDomain = normaliseURLDomainOrThrowError(apiDomain);
-        // @ts-ignore (Typescript complains that URL does not expect a parameter in constructor even though it does for react-native-url-polyfill)
-        let apiUrlObj: any = new URL(apiDomain);
-        return domain === (apiUrlObj.port === "" ? apiUrlObj.hostname : apiUrlObj.hostname + ":" + apiUrlObj.port);
-    } else {
-        let normalisedSessionDomain = normaliseCookieDomainOrThrowError(sessionTokenBackendDomain);
-        if (sessionTokenBackendDomain.split(":").length > 1) {
-            // this means that a port may have been provided
-            let portStr = sessionTokenBackendDomain.split(":")[sessionTokenBackendDomain.split(":").length - 1];
-            if (isNumeric(portStr)) {
-                normalisedSessionDomain += ":" + portStr;
-                domain = urlObj.port === "" ? domain : domain + ":" + urlObj.port;
-            }
-        }
-        if (sessionTokenBackendDomain.startsWith(".")) {
-            return ("." + domain).endsWith(normalisedSessionDomain);
-        } else {
-            return domain === normalisedSessionDomain;
-        }
-    }
 }
 
 export function setToken(tokenType: TokenType, value: string) {

--- a/lib/ts/version.ts
+++ b/lib/ts/version.ts
@@ -12,6 +12,6 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-export const package_version = "4.0.3";
+export const package_version = "4.0.4";
 
 export const supported_fdi = ["1.16"];

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "supertokens-react-native",
-  "version": "4.0.3",
+  "version": "4.0.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "supertokens-react-native",
-      "version": "4.0.3",
+      "version": "4.0.4",
       "license": "Apache 2.0",
       "dependencies": {
         "base-64": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "supertokens-react-native",
-  "version": "4.0.3",
+  "version": "4.0.4",
   "description": "React Native SDK for SuperTokens",
   "main": "index.js",
   "scripts": {

--- a/test/playground/index.ts
+++ b/test/playground/index.ts
@@ -123,3 +123,18 @@ init({
         }
     }
 });
+
+init({
+    apiDomain: "",
+    override: {
+        functions: (oI) => {
+            return {
+                ...oI,
+                // Defining the input variables like this also typechecks the signature of it in future releases
+                shouldDoInterceptionBasedOnUrl: (toCheckUrl: string, apiDomain: string, sessionTokenBackendDomain: string) => {
+                    return true;
+                },
+            };
+        },
+    },
+})


### PR DESCRIPTION
## Summary of change
- `shouldDoInterceptionBasedOnUrl` is now a recipe function allowing users to override and opt out of interception based on the url
- Changes interception logic when adding the authorisation bearer token in the headers

## Related issues
- 

## Test Plan
New tests have been added

## Documentation changes
NA

## Checklist for important updates
- [x] Changelog has been updated
- [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
   - Along with the associated array in `lib/ts/version.ts`
- [x] Changes to the version if needed
   - In `package.json`
   - In `package-lock.json`
   - In `lib/ts/version.ts`
- [x] Had run `npm run build-pretty`
- [x] Had installed and ran the pre-commit hook
- [x] Issue this PR against the latest non released version branch.
   - To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
   - If no such branch exists, then create one from the latest released branch.

## Remaining TODOs for this PR
- [ ] ...