### PR TITLE
fix: use URL polyfill for shouldDoInterceptionBasedOnUrl

### DIFF
--- a/lib/ts/recipeImplementation.ts
+++ b/lib/ts/recipeImplementation.ts
@@ -1,3 +1,4 @@
+import { URL } from "react-native-url-polyfill";
 import { RecipeInterface, NormalisedInputType } from "./types";
 import AuthHttpRequest, { onUnauthorisedResponse } from "./fetch";
 import FrontToken from "./frontToken";


### PR DESCRIPTION
## Summary of change
Use URL polyfill from "react-native-url-polyfill" as it is done in all other files.

## Related issues
Fixes `ERROR  [Error: URL.hostname is not implemented]` when using the library with fetch.