### PR TITLE
Sessionscope fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [5.0.0] - 2024-05-08
+
+### Breaking changes
+
+The `shouldDoInterceptionBasedOnUrl` function now returns true: 
+- If `sessionTokenBackendDomain` is a valid subdomain of the URL's domain. This aligns with the behavior of browsers when sending cookies to subdomains.
+- Even if the ports of the URL you are querying are different compared to the `apiDomain`'s port ot the `sessionTokenBackendDomain` port (as long as the hostname is the same, or a subdomain of the `sessionTokenBackendDomain`): https://github.com/supertokens/supertokens-website/issues/217
+
 ## [4.1.1] - 2024-03-14
 
 - Support for new FDI version - 1.19

--- a/TestingApp/test/config.spec.js
+++ b/TestingApp/test/config.spec.js
@@ -20,8 +20,7 @@ import { ProcessState } from "supertokens-react-native/lib/build/processState";
 import {
     normaliseCookieDomainOrThrowError,
     normaliseURLPathOrThrowError,
-    normaliseURLDomainOrThrowError,
-    shouldDoInterceptionBasedOnUrl
+    normaliseURLDomainOrThrowError
 } from "supertokens-react-native/lib/build/utils";
 // jest does not call setupFiles properly with the new react-native init, so doing it this way instead
 import "./setup";
@@ -59,6 +58,9 @@ describe("Config tests", function() {
         );
         assert(shouldDoInterceptionBasedOnUrl("localhost:3000", "localhost:3000", undefined));
         assert(shouldDoInterceptionBasedOnUrl("https://localhost:3000", "https://localhost:3000", undefined));
+        assert(shouldDoInterceptionBasedOnUrl("https://localhost:3000", "https://localhost:3001", undefined));
+        assert(shouldDoInterceptionBasedOnUrl("http://localhost:3000", "http://localhost:3001", undefined));
+        assert(shouldDoInterceptionBasedOnUrl("localhost:3000", "localhost:3001", undefined));
         assert(shouldDoInterceptionBasedOnUrl("http://localhost:3000", "http://localhost:3000", undefined));
         assert(shouldDoInterceptionBasedOnUrl("localhost:3000", "https://localhost:3000", undefined));
         assert(shouldDoInterceptionBasedOnUrl("localhost", "https://localhost", undefined));
@@ -69,19 +71,29 @@ describe("Config tests", function() {
         assert(shouldDoInterceptionBasedOnUrl("127.0.0.1:3000", "https://127.0.0.1:3000", undefined));
         assert(shouldDoInterceptionBasedOnUrl("http://127.0.0.1:3000", "https://127.0.0.1:3000", undefined));
         assert(shouldDoInterceptionBasedOnUrl("http://127.0.0.1", "https://127.0.0.1", undefined));
+        assert(shouldDoInterceptionBasedOnUrl("http://localhost.org", "localhost.org", undefined));
+        assert(shouldDoInterceptionBasedOnUrl("http://localhost.org", "http://localhost.org", undefined));
 
         // true cases with cookieDomain
         assert(shouldDoInterceptionBasedOnUrl("api.example.com", "", "api.example.com"));
         assert(shouldDoInterceptionBasedOnUrl("http://api.example.com", "", "http://api.example.com"));
         assert(shouldDoInterceptionBasedOnUrl("api.example.com", "", ".example.com"));
+        assert(shouldDoInterceptionBasedOnUrl("api.example.com", "", "example.com"));
         assert(shouldDoInterceptionBasedOnUrl("https://api.example.com", "", "http://api.example.com"));
         assert(shouldDoInterceptionBasedOnUrl("https://api.example.com", "", "https://api.example.com"));
+        assert(shouldDoInterceptionBasedOnUrl("https://sub.api.example.com", "", ".sub.api.example.com"));
+        assert(shouldDoInterceptionBasedOnUrl("https://sub.api.example.com", "", "sub.api.example.com"));
         assert(shouldDoInterceptionBasedOnUrl("https://sub.api.example.com", "", ".api.example.com"));
+        assert(shouldDoInterceptionBasedOnUrl("https://sub.api.example.com", "", "api.example.com"));
         assert(shouldDoInterceptionBasedOnUrl("https://sub.api.example.com", "", ".example.com"));
+        assert(shouldDoInterceptionBasedOnUrl("https://sub.api.example.com", "", "example.com"));
         assert(shouldDoInterceptionBasedOnUrl("https://sub.api.example.com:3000", "", ".example.com:3000"));
+        assert(shouldDoInterceptionBasedOnUrl("https://sub.api.example.com:3000", "", "example.com:3000"));
         assert(shouldDoInterceptionBasedOnUrl("https://sub.api.example.com:3000", "", ".example.com"));
+        assert(shouldDoInterceptionBasedOnUrl("https://sub.api.example.com:3000", "", "example.com"));
         assert(shouldDoInterceptionBasedOnUrl("https://sub.api.example.com:3000", "", "https://sub.api.example.com"));
         assert(shouldDoInterceptionBasedOnUrl("https://api.example.com:3000", "", ".api.example.com"));
+        assert(shouldDoInterceptionBasedOnUrl("https://api.example.com:3000", "", "api.example.com"));
         assert(shouldDoInterceptionBasedOnUrl("localhost:3000", "", "localhost:3000"));
         assert(shouldDoInterceptionBasedOnUrl("https://localhost:3000", "", ".localhost:3000"));
         assert(shouldDoInterceptionBasedOnUrl("localhost", "", "localhost"));
@@ -92,32 +104,51 @@ describe("Config tests", function() {
         assert(shouldDoInterceptionBasedOnUrl("127.0.0.1:3000", "", "https://127.0.0.1:3000"));
         assert(shouldDoInterceptionBasedOnUrl("http://127.0.0.1:3000", "", "https://127.0.0.1:3000"));
         assert(shouldDoInterceptionBasedOnUrl("http://127.0.0.1", "", "https://127.0.0.1"));
+        assert(shouldDoInterceptionBasedOnUrl("http://localhost.org", "", ".localhost.org"));
+        assert(shouldDoInterceptionBasedOnUrl("http://localhost.org", "", "localhost.org"));
         assert(shouldDoInterceptionBasedOnUrl("https://sub.api.example.com:3000", "", ".com"));
         assert(shouldDoInterceptionBasedOnUrl("https://sub.api.example.co.uk:3000", "", ".api.example.co.uk"));
         assert(shouldDoInterceptionBasedOnUrl("https://sub1.api.example.co.uk:3000", "", ".api.example.co.uk"));
         assert(shouldDoInterceptionBasedOnUrl("https://api.example.co.uk:3000", "", ".api.example.co.uk"));
         assert(shouldDoInterceptionBasedOnUrl("https://api.example.co.uk:3000", "", "api.example.co.uk"));
+        assert(shouldDoInterceptionBasedOnUrl("localhost:3000", "localhost:8080", undefined));
+        assert(shouldDoInterceptionBasedOnUrl("localhost:3001", "localhost", undefined));
+        assert(
+            shouldDoInterceptionBasedOnUrl("https://api.example.com:3002", "https://api.example.com:3001", undefined)
+        );
+        assert(shouldDoInterceptionBasedOnUrl("http://localhost.org", "localhost.org:2000", undefined));
+        assert(shouldDoInterceptionBasedOnUrl("http://localhost.org", "localhost", "localhost.org"));
+        assert(shouldDoInterceptionBasedOnUrl("localhost", "localhost", "localhost.org"));
+        assert(shouldDoInterceptionBasedOnUrl("localhost", "", "localhost:8080"));
+        assert(shouldDoInterceptionBasedOnUrl("http://localhost:80", "", "localhost:8080"));
+        assert(shouldDoInterceptionBasedOnUrl("localhost:3000", "", "localhost:8080"));
+        assert(shouldDoInterceptionBasedOnUrl("https://sub.api.example.com:3000", "", ".example.com:3001"));
+        assert(shouldDoInterceptionBasedOnUrl("http://127.0.0.1:3000", "", "https://127.0.0.1:3010"));
 
         // false cases with api
-        assert(!shouldDoInterceptionBasedOnUrl("localhost:3001", "localhost:3000", undefined));
+        assert(!shouldDoInterceptionBasedOnUrl("localhost", "localhost.org"));
+        assert(!shouldDoInterceptionBasedOnUrl("google.com", "localhost.org"));
+        assert(!shouldDoInterceptionBasedOnUrl("http://google.com", "localhost.org"));
+        assert(!shouldDoInterceptionBasedOnUrl("https://google.com", "localhost.org"));
+        assert(!shouldDoInterceptionBasedOnUrl("https://google.com:8080", "localhost.org"));
         assert(!shouldDoInterceptionBasedOnUrl("localhost:3001", "example.com", undefined));
-        assert(!shouldDoInterceptionBasedOnUrl("localhost:3001", "localhost", undefined));
         assert(!shouldDoInterceptionBasedOnUrl("https://example.com", "https://api.example.com", undefined));
         assert(!shouldDoInterceptionBasedOnUrl("https://api.example.com", "https://a.api.example.com", undefined));
+        assert(!shouldDoInterceptionBasedOnUrl("https://api.example.com", "https://a.api.example.com:3000", undefined));
         assert(!shouldDoInterceptionBasedOnUrl("https://api.example.com", "https://example.com", undefined));
         assert(!shouldDoInterceptionBasedOnUrl("https://example.com:3001", "https://api.example.com:3001", undefined));
-        assert(
-            !shouldDoInterceptionBasedOnUrl("https://api.example.com:3002", "https://api.example.com:3001", undefined)
-        );
 
         // false cases with cookieDomain
-        assert(!shouldDoInterceptionBasedOnUrl("https://sub.api.example.com:3000", "", ".example.com:3001"));
-        assert(!shouldDoInterceptionBasedOnUrl("https://sub.api.example.com:3000", "", "example.com"));
+        assert(!shouldDoInterceptionBasedOnUrl("localhost", "", "localhost.org"));
+        assert(!shouldDoInterceptionBasedOnUrl("google.com", "", "localhost.org"));
+        assert(!shouldDoInterceptionBasedOnUrl("http://google.com", "", "localhost.org"));
+        assert(!shouldDoInterceptionBasedOnUrl("https://google.com", "", "localhost.org"));
+        assert(!shouldDoInterceptionBasedOnUrl("https://google.com:8080", "", "localhost.org"));
         assert(!shouldDoInterceptionBasedOnUrl("https://api.example.com:3000", "", ".a.api.example.com"));
         assert(!shouldDoInterceptionBasedOnUrl("https://sub.api.example.com:3000", "", "localhost"));
-        assert(!shouldDoInterceptionBasedOnUrl("http://127.0.0.1:3000", "", "https://127.0.0.1:3010"));
-        assert(!shouldDoInterceptionBasedOnUrl("https://sub.api.example.co.uk:3000", "", "api.example.co.uk"));
-        assert(!shouldDoInterceptionBasedOnUrl("https://sub.api.example.co.uk", "", "api.example.co.uk"));
+        assert(!shouldDoInterceptionBasedOnUrl("http://localhost.org", "", "localhost"));
+        assert(!shouldDoInterceptionBasedOnUrl("http://localhost.org", "", ".localhost"));
+        assert(!shouldDoInterceptionBasedOnUrl("http://localhost.org", "", "localhost:2000"));
 
         // errors in input
         try {

--- a/android/.project
+++ b/android/.project
@@ -14,4 +14,15 @@
 	<natures>
 		<nature>org.eclipse.buildship.core.gradleprojectnature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1715168216601</id>
+			<name></name>
+			<type>30</type>
+			<matcher>
+				<id>org.eclipse.core.resources.regexFilterMatcher</id>
+				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/android/.project
+++ b/android/.project
@@ -14,15 +14,4 @@
 	<natures>
 		<nature>org.eclipse.buildship.core.gradleprojectnature</nature>
 	</natures>
-	<filteredResources>
-		<filter>
-			<id>1715168216601</id>
-			<name></name>
-			<type>30</type>
-			<matcher>
-				<id>org.eclipse.core.resources.regexFilterMatcher</id>
-				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
-			</matcher>
-		</filter>
-	</filteredResources>
 </projectDescription>

--- a/lib/build/recipeImplementation.js
+++ b/lib/build/recipeImplementation.js
@@ -35,7 +35,7 @@ import FrontToken from "./frontToken";
 import { supported_fdi } from "./version";
 import { interceptorFunctionRequestFulfilled, responseErrorInterceptor, responseInterceptor } from "./axios";
 import { SuperTokensGeneralError } from "./error";
-import { getLocalSessionState, normaliseCookieDomainOrThrowError, normaliseURLDomainOrThrowError } from "./utils";
+import { getLocalSessionState, normaliseSessionScopeOrThrowError, normaliseURLDomainOrThrowError } from "./utils";
 import { logDebugMessage } from "./logger";
 export default function RecipeImplementation() {
     return {
@@ -165,7 +165,7 @@ export default function RecipeImplementation() {
                 // we do not send an event here since it's triggered in fireSessionUpdateEventsIfNecessary.
             });
         },
-        shouldDoInterceptionBasedOnUrl: (toCheckUrl, apiDomain, sessionTokenBackendDomain) => {
+        shouldDoInterceptionBasedOnUrl: function(toCheckUrl, apiDomain, sessionTokenBackendDomain) {
             logDebugMessage(
                 "shouldDoInterceptionBasedOnUrl: toCheckUrl: " +
                     toCheckUrl +
@@ -174,40 +174,39 @@ export default function RecipeImplementation() {
                     " sessionTokenBackendDomain: " +
                     sessionTokenBackendDomain
             );
-            function isNumeric(str) {
-                if (typeof str != "string") return false; // we only process strings!
-                return (
-                    !isNaN(str) && !isNaN(parseFloat(str)) // use type coercion to parse the _entirety_ of the string (`parseFloat` alone does not do this)...
-                ); // ...and ensure strings of whitespace fail
+            // The safest/best way to add this is the hash as the browser strips it before sending
+            // but we don't have a reason to limit checking to that part.
+            if (toCheckUrl.includes("superTokensDoNotDoInterception")) {
+                return false;
             }
             toCheckUrl = normaliseURLDomainOrThrowError(toCheckUrl);
-            // @ts-ignore (Typescript complains that URL does not expect a parameter in constructor even though it does for react-native-url-polyfill)
             let urlObj = new URL(toCheckUrl);
             let domain = urlObj.hostname;
-            if (sessionTokenBackendDomain === undefined) {
-                domain = urlObj.port === "" ? domain : domain + ":" + urlObj.port;
+            let apiDomainAndInputDomainMatch = false;
+            if (apiDomain !== "") {
+                // we have the "" check cause in tests, we pass "" in lots of cases.
                 apiDomain = normaliseURLDomainOrThrowError(apiDomain);
-                // @ts-ignore (Typescript complains that URL does not expect a parameter in constructor even though it does for react-native-url-polyfill)
                 let apiUrlObj = new URL(apiDomain);
-                return (
-                    domain === (apiUrlObj.port === "" ? apiUrlObj.hostname : apiUrlObj.hostname + ":" + apiUrlObj.port)
-                );
+                apiDomainAndInputDomainMatch = domain === apiUrlObj.hostname;
+            }
+            if (sessionTokenBackendDomain === undefined || apiDomainAndInputDomainMatch) {
+                // even if sessionTokenBackendDomain !== undefined, if there is an exact match
+                // of api domain, ignoring the port, we return true
+                return apiDomainAndInputDomainMatch;
             } else {
-                let normalisedSessionDomain = normaliseCookieDomainOrThrowError(sessionTokenBackendDomain);
-                if (sessionTokenBackendDomain.split(":").length > 1) {
-                    // this means that a port may have been provided
-                    let portStr = sessionTokenBackendDomain.split(":")[sessionTokenBackendDomain.split(":").length - 1];
-                    if (isNumeric(portStr)) {
-                        normalisedSessionDomain += ":" + portStr;
-                        domain = urlObj.port === "" ? domain : domain + ":" + urlObj.port;
-                    }
-                }
-                if (sessionTokenBackendDomain.startsWith(".")) {
-                    return ("." + domain).endsWith(normalisedSessionDomain);
-                } else {
-                    return domain === normalisedSessionDomain;
-                }
+                let normalisedsessionDomain = normaliseSessionScopeOrThrowError(sessionTokenBackendDomain);
+                return matchesDomainOrSubdomain(domain, normalisedsessionDomain);
             }
         }
     };
+}
+function matchesDomainOrSubdomain(hostname, str) {
+    const parts = hostname.split(".");
+    for (let i = 0; i < parts.length; i++) {
+        const subdomainCandidate = parts.slice(i).join(".");
+        if (subdomainCandidate === str || `.${subdomainCandidate}` === str) {
+            return true;
+        }
+    }
+    return false;
 }

--- a/lib/build/utils.d.ts
+++ b/lib/build/utils.d.ts
@@ -2,7 +2,7 @@ import { InputType, NormalisedInputType, TokenType } from "./types";
 export declare function isAnIpAddress(ipaddress: string): boolean;
 export declare function normaliseURLDomainOrThrowError(input: string): string;
 export declare function normaliseURLPathOrThrowError(input: string): string;
-export declare function normaliseCookieDomainOrThrowError(cookieDomain: string): string;
+export declare function normaliseSessionScopeOrThrowError(cookieDomain: string): string;
 export declare function validateAndNormaliseInputOrThrowError(options: InputType): NormalisedInputType;
 export declare function setToken(tokenType: TokenType, value: string): Promise<void>;
 export declare function storeInStorage(name: string, value: string, expiry: number): Promise<void>;

--- a/lib/build/utils.js
+++ b/lib/build/utils.js
@@ -51,7 +51,7 @@ export function normaliseURLDomainOrThrowError(input) {
 export function normaliseURLPathOrThrowError(input) {
     return new NormalisedURLPath(input).getAsStringDangerous();
 }
-export function normaliseCookieDomainOrThrowError(cookieDomain) {
+export function normaliseSessionScopeOrThrowError(cookieDomain) {
     function helper(cookieDomain) {
         cookieDomain = cookieDomain.trim().toLowerCase();
         // first we convert it to a URL so that we can use the URL class
@@ -65,10 +65,6 @@ export function normaliseCookieDomainOrThrowError(cookieDomain) {
             // @ts-ignore (Typescript complains that URL does not expect a parameter in constructor even though it does for react-native-url-polyfill)
             let urlObj = new URL(cookieDomain);
             cookieDomain = urlObj.hostname;
-            // remove leading dot
-            if (cookieDomain.startsWith(".")) {
-                cookieDomain = cookieDomain.substr(1);
-            }
             return cookieDomain;
         } catch (err) {
             throw new Error("Please provide a valid cookieDomain");
@@ -104,7 +100,7 @@ export function validateAndNormaliseInputOrThrowError(options) {
     }
     let sessionTokenBackendDomain = undefined;
     if (options.sessionTokenBackendDomain !== undefined) {
-        sessionTokenBackendDomain = normaliseCookieDomainOrThrowError(options.sessionTokenBackendDomain);
+        sessionTokenBackendDomain = normaliseSessionScopeOrThrowError(options.sessionTokenBackendDomain);
     }
     let preAPIHook = context =>
         __awaiter(this, void 0, void 0, function*() {

--- a/lib/build/version.d.ts
+++ b/lib/build/version.d.ts
@@ -1,2 +1,2 @@
-export declare const package_version = "4.1.1";
+export declare const package_version = "5.0.0";
 export declare const supported_fdi: string[];

--- a/lib/build/version.js
+++ b/lib/build/version.js
@@ -12,5 +12,5 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-export const package_version = "4.1.1";
+export const package_version = "5.0.0";
 export const supported_fdi = ["1.16", "1.17", "1.18", "1.19"];

--- a/lib/ts/utils.ts
+++ b/lib/ts/utils.ts
@@ -26,7 +26,7 @@ export function normaliseURLPathOrThrowError(input: string): string {
     return new NormalisedURLPath(input).getAsStringDangerous();
 }
 
-export function normaliseCookieDomainOrThrowError(cookieDomain: string): string {
+export function normaliseSessionScopeOrThrowError(cookieDomain: string): string {
     function helper(cookieDomain: string): string {
         cookieDomain = cookieDomain.trim().toLowerCase();
 
@@ -43,11 +43,6 @@ export function normaliseCookieDomainOrThrowError(cookieDomain: string): string 
             // @ts-ignore (Typescript complains that URL does not expect a parameter in constructor even though it does for react-native-url-polyfill)
             let urlObj: any = new URL(cookieDomain);
             cookieDomain = urlObj.hostname;
-
-            // remove leading dot
-            if (cookieDomain.startsWith(".")) {
-                cookieDomain = cookieDomain.substr(1);
-            }
 
             return cookieDomain;
         } catch (err) {
@@ -94,7 +89,7 @@ export function validateAndNormaliseInputOrThrowError(options: InputType): Norma
 
     let sessionTokenBackendDomain: string | undefined = undefined;
     if (options.sessionTokenBackendDomain !== undefined) {
-        sessionTokenBackendDomain = normaliseCookieDomainOrThrowError(options.sessionTokenBackendDomain);
+        sessionTokenBackendDomain = normaliseSessionScopeOrThrowError(options.sessionTokenBackendDomain);
     }
 
     let preAPIHook = async (context: {

--- a/lib/ts/version.ts
+++ b/lib/ts/version.ts
@@ -12,6 +12,6 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-export const package_version = "4.1.1";
+export const package_version = "5.0.0";
 
 export const supported_fdi = ["1.16", "1.17", "1.18", "1.19"];

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "supertokens-react-native",
-  "version": "4.1.1",
+  "version": "5.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "supertokens-react-native",
-      "version": "4.1.1",
+      "version": "5.0.0",
       "license": "Apache 2.0",
       "dependencies": {
         "base-64": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "supertokens-react-native",
-  "version": "4.1.1",
+  "version": "5.0.0",
   "description": "React Native SDK for SuperTokens",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Summary of change

The `shouldDoInterceptionBasedOnUrl` function now returns true if `sessionTokenBackendDomain` is a valid subdomain of the URL's domain. This aligns with the behavior of browsers when sending cookies to subdomains.

## Related issues
- https://github.com/supertokens/supertokens-node/issues/826
- https://github.com/supertokens/supertokens-website/issues/217

## Test Plan
(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Documentation changes
(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates
- [ ] Changelog has been updated
- [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
   - Along with the associated array in `lib/ts/version.ts`
- [ ] Changes to the version if needed
   - In `package.json`
   - In `package-lock.json`
   - In `lib/ts/version.ts`
- [ ] Had run `npm run build-pretty`
- [ ] Had installed and ran the pre-commit hook
- [ ] Issue this PR against the latest non released version branch.
   - To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
   - If no such branch exists, then create one from the latest released branch.

## Remaining TODOs for this PR
- [ ] Item1
- [ ] Item2