### PR TITLE
Remove dependency on punycode

### DIFF
--- a/lib/build/antiCsrf.js
+++ b/lib/build/antiCsrf.js
@@ -12,53 +12,31 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-var __awaiter =
-    (this && this.__awaiter) ||
-    function(thisArg, _arguments, P, generator) {
-        function adopt(value) {
-            return value instanceof P
-                ? value
-                : new P(function(resolve) {
-                      resolve(value);
-                  });
-        }
-        return new (P || (P = Promise))(function(resolve, reject) {
-            function fulfilled(value) {
-                try {
-                    step(generator.next(value));
-                } catch (e) {
-                    reject(e);
-                }
-            }
-            function rejected(value) {
-                try {
-                    step(generator["throw"](value));
-                } catch (e) {
-                    reject(e);
-                }
-            }
-            function step(result) {
-                result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
-            }
-            step((generator = generator.apply(thisArg, _arguments || [])).next());
-        });
-    };
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import { getLocalSessionState } from "./utils";
 import { logDebugMessage } from "./logger";
 const TOKEN_KEY = "supertokens-rn-anticsrf-key";
 const ANTI_CSRF_NAME = "sAntiCsrf";
 export default class AntiCSRF {
-    constructor() {}
+    constructor() { }
     static getAntiCSRFToken(associatedAccessTokenUpdate) {
-        return __awaiter(this, void 0, void 0, function*() {
+        return __awaiter(this, void 0, void 0, function* () {
             logDebugMessage("AntiCSRF.getAntiCSRFToken: called");
             if (!((yield getLocalSessionState()).status === "EXISTS")) {
                 logDebugMessage("AntiCSRF.getAntiCSRFToken: returning null because local session state != EXISTS");
                 return null;
             }
             function getAntiCSRFFromStorage() {
-                return __awaiter(this, void 0, void 0, function*() {
+                return __awaiter(this, void 0, void 0, function* () {
                     let fromStorage = yield AsyncStorage.getItem(TOKEN_KEY);
                     if (fromStorage !== null) {
                         return fromStorage;
@@ -100,7 +78,7 @@ export default class AntiCSRF {
         });
     }
     static getToken(associatedAccessTokenUpdate) {
-        return __awaiter(this, void 0, void 0, function*() {
+        return __awaiter(this, void 0, void 0, function* () {
             logDebugMessage("AntiCSRF.getToken: called");
             if (associatedAccessTokenUpdate === undefined) {
                 AntiCSRF.tokenInfo = undefined;
@@ -117,7 +95,8 @@ export default class AntiCSRF {
                     antiCsrf,
                     associatedAccessTokenUpdate
                 };
-            } else if (AntiCSRF.tokenInfo.associatedAccessTokenUpdate !== associatedAccessTokenUpdate) {
+            }
+            else if (AntiCSRF.tokenInfo.associatedAccessTokenUpdate !== associatedAccessTokenUpdate) {
                 // csrf token has changed.
                 AntiCSRF.tokenInfo = undefined;
                 return yield AntiCSRF.getToken(associatedAccessTokenUpdate);
@@ -128,13 +107,14 @@ export default class AntiCSRF {
     }
     // give antiCSRFToken as undefined to remove it.
     static setAntiCSRF(antiCSRFToken) {
-        return __awaiter(this, void 0, void 0, function*() {
+        return __awaiter(this, void 0, void 0, function* () {
             logDebugMessage("AntiCSRF.setAntiCSRF: called " + antiCSRFToken);
             function setAntiCSRFToStorage(antiCSRFToken) {
-                return __awaiter(this, void 0, void 0, function*() {
+                return __awaiter(this, void 0, void 0, function* () {
                     if (antiCSRFToken === undefined) {
                         yield AntiCSRF.removeToken();
-                    } else {
+                    }
+                    else {
                         yield AsyncStorage.setItem(TOKEN_KEY, antiCSRFToken);
                     }
                 });
@@ -143,7 +123,7 @@ export default class AntiCSRF {
         });
     }
     static setItem(associatedAccessTokenUpdate, antiCsrf) {
-        return __awaiter(this, void 0, void 0, function*() {
+        return __awaiter(this, void 0, void 0, function* () {
             if (associatedAccessTokenUpdate === undefined) {
                 AntiCSRF.tokenInfo = undefined;
                 return;
@@ -157,7 +137,7 @@ export default class AntiCSRF {
         });
     }
     static removeToken() {
-        return __awaiter(this, void 0, void 0, function*() {
+        return __awaiter(this, void 0, void 0, function* () {
             logDebugMessage("AntiCSRF.removeToken: called");
             AntiCSRF.tokenInfo = undefined;
             yield AsyncStorage.removeItem(TOKEN_KEY);

--- a/lib/build/axios.d.ts
+++ b/lib/build/axios.d.ts
@@ -4,7 +4,7 @@ declare type AxiosRequestConfig = OriginalAxiosRequestConfig & {
     __supertokensAddedAuthHeader?: boolean;
 };
 export declare function interceptorFunctionRequestFulfilled(config: AxiosRequestConfig): Promise<AxiosRequestConfig>;
-export declare function responseInterceptor(axiosInstance: any): (response: AxiosResponse<any>) => Promise<AxiosResponse<any>>;
+export declare function responseInterceptor(axiosInstance: any): (response: AxiosResponse) => Promise<AxiosResponse<any>>;
 export declare function responseErrorInterceptor(axiosInstance: any): (error: any) => Promise<AxiosResponse<any>>;
 /**
  * @class AuthHttpRequest

--- a/lib/build/axios.js
+++ b/lib/build/axios.js
@@ -1,34 +1,13 @@
-var __awaiter =
-    (this && this.__awaiter) ||
-    function(thisArg, _arguments, P, generator) {
-        function adopt(value) {
-            return value instanceof P
-                ? value
-                : new P(function(resolve) {
-                      resolve(value);
-                  });
-        }
-        return new (P || (P = Promise))(function(resolve, reject) {
-            function fulfilled(value) {
-                try {
-                    step(generator.next(value));
-                } catch (e) {
-                    reject(e);
-                }
-            }
-            function rejected(value) {
-                try {
-                    step(generator["throw"](value));
-                } catch (e) {
-                    reject(e);
-                }
-            }
-            function step(result) {
-                result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
-            }
-            step((generator = generator.apply(thisArg, _arguments || [])).next());
-        });
-    };
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var _a;
 import { createAxiosErrorFromFetchResp } from "./axiosError";
 import AuthHttpRequestFetch, { onUnauthorisedResponse } from "./fetch";
 import FrontToken from "./frontToken";
@@ -54,28 +33,27 @@ function getUrlFromConfig(config) {
     if (baseURL !== undefined) {
         if (url.charAt(0) === "/" && baseURL.charAt(baseURL.length - 1) === "/") {
             url = baseURL + url.substr(1);
-        } else if (url.charAt(0) !== "/" && baseURL.charAt(baseURL.length - 1) !== "/") {
+        }
+        else if (url.charAt(0) !== "/" && baseURL.charAt(baseURL.length - 1) !== "/") {
             url = baseURL + "/" + url;
-        } else {
+        }
+        else {
             url = baseURL + url;
         }
     }
     return url;
 }
 export function interceptorFunctionRequestFulfilled(config) {
-    return __awaiter(this, void 0, void 0, function*() {
+    return __awaiter(this, void 0, void 0, function* () {
         logDebugMessage("interceptorFunctionRequestFulfilled: started axios interception");
         let url = getUrlFromConfig(config);
         let doNotDoInterception = false;
         try {
             doNotDoInterception =
                 typeof url === "string" &&
-                !AuthHttpRequestFetch.recipeImpl.shouldDoInterceptionBasedOnUrl(
-                    url,
-                    AuthHttpRequestFetch.config.apiDomain,
-                    AuthHttpRequestFetch.config.sessionTokenBackendDomain
-                );
-        } catch (err) {
+                    !AuthHttpRequestFetch.recipeImpl.shouldDoInterceptionBasedOnUrl(url, AuthHttpRequestFetch.config.apiDomain, AuthHttpRequestFetch.config.sessionTokenBackendDomain);
+        }
+        catch (err) {
             // This is because when this function is called we always have a full URL (refer to getUrlFromConfig),
             // so we do not need to check for the case where axios is called with just a path (for example axios.post("/login"))
             throw err;
@@ -94,16 +72,11 @@ export function interceptorFunctionRequestFulfilled(config) {
             const antiCsrfToken = yield AntiCSRF.getToken(preRequestLocalSessionState.lastAccessTokenUpdate);
             if (antiCsrfToken !== undefined) {
                 logDebugMessage("interceptorFunctionRequestFulfilled: Adding anti-csrf token to request");
-                configWithAntiCsrf = Object.assign(Object.assign({}, configWithAntiCsrf), {
-                    headers:
-                        configWithAntiCsrf === undefined
-                            ? {
-                                  "anti-csrf": antiCsrfToken
-                              }
-                            : Object.assign(Object.assign({}, configWithAntiCsrf.headers), {
-                                  "anti-csrf": antiCsrfToken
-                              })
-                });
+                configWithAntiCsrf = Object.assign(Object.assign({}, configWithAntiCsrf), { headers: configWithAntiCsrf === undefined
+                        ? {
+                            "anti-csrf": antiCsrfToken
+                        }
+                        : Object.assign(Object.assign({}, configWithAntiCsrf.headers), { "anti-csrf": antiCsrfToken }) });
             }
         }
         if (AuthHttpRequestFetch.config.autoAddCredentials && configWithAntiCsrf.withCredentials === undefined) {
@@ -111,17 +84,12 @@ export function interceptorFunctionRequestFulfilled(config) {
             configWithAntiCsrf = Object.assign(Object.assign({}, configWithAntiCsrf), { withCredentials: true });
         }
         // adding rid for anti-csrf protection: Anti-csrf via custom header
-        logDebugMessage(
-            "interceptorFunctionRequestFulfilled: Adding rid header: anti-csrf (it may be overriden by the user's provided rid)"
-        );
-        configWithAntiCsrf = Object.assign(Object.assign({}, configWithAntiCsrf), {
-            headers:
-                configWithAntiCsrf === undefined
-                    ? {
-                          rid: "anti-csrf"
-                      }
-                    : Object.assign({ rid: "anti-csrf" }, configWithAntiCsrf.headers)
-        });
+        logDebugMessage("interceptorFunctionRequestFulfilled: Adding rid header: anti-csrf (it may be overriden by the user's provided rid)");
+        configWithAntiCsrf = Object.assign(Object.assign({}, configWithAntiCsrf), { headers: configWithAntiCsrf === undefined
+                ? {
+                    rid: "anti-csrf"
+                }
+                : Object.assign({ rid: "anti-csrf" }, configWithAntiCsrf.headers) });
         const transferMethod = AuthHttpRequestFetch.config.tokenTransferMethod;
         logDebugMessage("interceptorFunctionRequestFulfilled: Adding st-auth-mode header: " + transferMethod);
         configWithAntiCsrf.headers["st-auth-mode"] = transferMethod;
@@ -132,92 +100,67 @@ export function interceptorFunctionRequestFulfilled(config) {
     });
 }
 export function responseInterceptor(axiosInstance) {
-    return response =>
-        __awaiter(this, void 0, void 0, function*() {
-            let doNotDoInterception = false;
-            if (!AuthHttpRequestFetch.initCalled) {
-                throw new Error("init function not called");
-            }
-            logDebugMessage("responseInterceptor: started");
-            logDebugMessage(
-                "responseInterceptor: already intercepted: " + response.headers["x-supertokens-xhr-intercepted"]
-            );
-            let url = getUrlFromConfig(response.config);
-            try {
-                doNotDoInterception =
-                    typeof url === "string" &&
-                    !AuthHttpRequestFetch.recipeImpl.shouldDoInterceptionBasedOnUrl(
-                        url,
-                        AuthHttpRequestFetch.config.apiDomain,
-                        AuthHttpRequestFetch.config.sessionTokenBackendDomain
-                    );
-            } catch (err) {
-                // This is because when this function is called we always have a full URL (refer to getUrlFromConfig),
-                // so we do not need to check for the case where axios is called with just a path (for example axios.post("/login"))
-                throw err;
-            }
-            logDebugMessage("responseInterceptor: Value of doNotDoInterception: " + doNotDoInterception);
-            if (doNotDoInterception) {
-                logDebugMessage("responseInterceptor: Returning without interception");
-                // this check means that if you are using axios via inteceptor, then we only do the refresh steps if you are calling your APIs.
-                return response;
-            }
-            logDebugMessage("responseInterceptor: Interception started");
-            ProcessState.getInstance().addState(PROCESS_STATE.CALLING_INTERCEPTION_RESPONSE);
-            const preRequestLocalSessionState = yield getLocalSessionState();
-            yield saveTokensFromHeaders(response);
-            fireSessionUpdateEventsIfNecessary(
-                preRequestLocalSessionState.status === "EXISTS",
-                response.status,
-                response.headers["front-token"]
-            );
-            if (response.status === AuthHttpRequestFetch.config.sessionExpiredStatusCode) {
-                logDebugMessage("responseInterceptor: Status code is: " + response.status);
-                let config = response.config;
-                return AuthHttpRequest.doRequest(
-                    config => {
-                        // we create an instance since we don't want to intercept this.
-                        // const instance = axios.create();
-                        // return instance(config);
-                        return axiosInstance(config);
-                    },
-                    config,
-                    url,
-                    response,
-                    true
-                );
-            } else {
-                return response;
-            }
-        });
+    return (response) => __awaiter(this, void 0, void 0, function* () {
+        let doNotDoInterception = false;
+        if (!AuthHttpRequestFetch.initCalled) {
+            throw new Error("init function not called");
+        }
+        logDebugMessage("responseInterceptor: started");
+        logDebugMessage("responseInterceptor: already intercepted: " + response.headers["x-supertokens-xhr-intercepted"]);
+        let url = getUrlFromConfig(response.config);
+        try {
+            doNotDoInterception =
+                typeof url === "string" &&
+                    !AuthHttpRequestFetch.recipeImpl.shouldDoInterceptionBasedOnUrl(url, AuthHttpRequestFetch.config.apiDomain, AuthHttpRequestFetch.config.sessionTokenBackendDomain);
+        }
+        catch (err) {
+            // This is because when this function is called we always have a full URL (refer to getUrlFromConfig),
+            // so we do not need to check for the case where axios is called with just a path (for example axios.post("/login"))
+            throw err;
+        }
+        logDebugMessage("responseInterceptor: Value of doNotDoInterception: " + doNotDoInterception);
+        if (doNotDoInterception) {
+            logDebugMessage("responseInterceptor: Returning without interception");
+            // this check means that if you are using axios via inteceptor, then we only do the refresh steps if you are calling your APIs.
+            return response;
+        }
+        logDebugMessage("responseInterceptor: Interception started");
+        ProcessState.getInstance().addState(PROCESS_STATE.CALLING_INTERCEPTION_RESPONSE);
+        const preRequestLocalSessionState = yield getLocalSessionState();
+        yield saveTokensFromHeaders(response);
+        fireSessionUpdateEventsIfNecessary(preRequestLocalSessionState.status === "EXISTS", response.status, response.headers["front-token"]);
+        if (response.status === AuthHttpRequestFetch.config.sessionExpiredStatusCode) {
+            logDebugMessage("responseInterceptor: Status code is: " + response.status);
+            let config = response.config;
+            return AuthHttpRequest.doRequest((config) => {
+                // we create an instance since we don't want to intercept this.
+                // const instance = axios.create();
+                // return instance(config);
+                return axiosInstance(config);
+            }, config, url, response, true);
+        }
+        else {
+            return response;
+        }
+    });
 }
 export function responseErrorInterceptor(axiosInstance) {
-    return error => {
+    return (error) => {
         logDebugMessage("responseErrorInterceptor: called");
-        logDebugMessage(
-            "responseErrorInterceptor: already intercepted: " +
-                (error.response && error.response.headers["x-supertokens-xhr-intercepted"])
-        );
-        if (
-            error.response !== undefined &&
-            error.response.status === AuthHttpRequestFetch.config.sessionExpiredStatusCode
-        ) {
+        logDebugMessage("responseErrorInterceptor: already intercepted: " +
+            (error.response && error.response.headers["x-supertokens-xhr-intercepted"]));
+        if (error.response !== undefined &&
+            error.response.status === AuthHttpRequestFetch.config.sessionExpiredStatusCode) {
             logDebugMessage("responseErrorInterceptor: Status code is: " + error.response.status);
             let config = error.config;
-            return AuthHttpRequest.doRequest(
-                config => {
-                    // we create an instance since we don't want to intercept this.
-                    // const instance = axios.create();
-                    // return instance(config);
-                    return axiosInstance(config);
-                },
-                config,
-                getUrlFromConfig(config),
-                undefined,
-                error,
-                true
-            );
-        } else {
+            return AuthHttpRequest.doRequest((config) => {
+                // we create an instance since we don't want to intercept this.
+                // const instance = axios.create();
+                // return instance(config);
+                return axiosInstance(config);
+            }, config, getUrlFromConfig(config), undefined, error, true);
+        }
+        else {
             throw error;
         }
     };
@@ -226,166 +169,147 @@ export function responseErrorInterceptor(axiosInstance) {
  * @class AuthHttpRequest
  * @description wrapper for common http methods.
  */
-export default class AuthHttpRequest {}
+export default class AuthHttpRequest {
+}
+_a = AuthHttpRequest;
 /**
  * @description sends the actual http request and returns a response if successful/
  * If not successful due to session expiry reasons, it
  * attempts to call the refresh token API and if that is successful, calls this API again.
  * @throws Error
  */
-AuthHttpRequest.doRequest = (httpCall, config, url, prevResponse, prevError, viaInterceptor = false) =>
-    __awaiter(void 0, void 0, void 0, function*() {
-        if (!AuthHttpRequestFetch.initCalled) {
-            throw Error("init function not called");
-        }
-        logDebugMessage("doRequest: called");
-        let doNotDoInterception = false;
-        try {
-            doNotDoInterception =
-                typeof url === "string" &&
-                !AuthHttpRequestFetch.recipeImpl.shouldDoInterceptionBasedOnUrl(
-                    url,
-                    AuthHttpRequestFetch.config.apiDomain,
-                    AuthHttpRequestFetch.config.sessionTokenBackendDomain
-                ) &&
+AuthHttpRequest.doRequest = (httpCall, config, url, prevResponse, prevError, viaInterceptor = false) => __awaiter(void 0, void 0, void 0, function* () {
+    if (!AuthHttpRequestFetch.initCalled) {
+        throw Error("init function not called");
+    }
+    logDebugMessage("doRequest: called");
+    let doNotDoInterception = false;
+    try {
+        doNotDoInterception =
+            typeof url === "string" &&
+                !AuthHttpRequestFetch.recipeImpl.shouldDoInterceptionBasedOnUrl(url, AuthHttpRequestFetch.config.apiDomain, AuthHttpRequestFetch.config.sessionTokenBackendDomain) &&
                 viaInterceptor;
-        } catch (err) {
-            // This is because when this function is called we always have a full URL (refer to getUrlFromConfig),
-            // so we do not need to check for the case where axios is called with just a path (for example axios.post("/login"))
-            throw err;
+    }
+    catch (err) {
+        // This is because when this function is called we always have a full URL (refer to getUrlFromConfig),
+        // so we do not need to check for the case where axios is called with just a path (for example axios.post("/login"))
+        throw err;
+    }
+    logDebugMessage("doRequest: Value of doNotDoInterception: " + doNotDoInterception);
+    if (doNotDoInterception) {
+        logDebugMessage("doRequest: Returning without interception");
+        if (prevError !== undefined) {
+            throw prevError;
         }
-        logDebugMessage("doRequest: Value of doNotDoInterception: " + doNotDoInterception);
-        if (doNotDoInterception) {
-            logDebugMessage("doRequest: Returning without interception");
-            if (prevError !== undefined) {
-                throw prevError;
-            } else if (prevResponse !== undefined) {
-                return prevResponse;
-            }
-            return yield httpCall(config);
+        else if (prevResponse !== undefined) {
+            return prevResponse;
         }
-        logDebugMessage("doRequest: Interception started");
-        config = yield removeAuthHeaderIfMatchesLocalToken(config);
-        let returnObj = undefined;
-        while (true) {
-            // we read this here so that if there is a session expiry error, then we can compare this value (that caused the error) with the value after the request is sent.
-            // to avoid race conditions
-            const preRequestLocalSessionState = yield getLocalSessionState();
-            let configWithAntiCsrf = config;
-            if (preRequestLocalSessionState.status === "EXISTS") {
-                const antiCsrfToken = yield AntiCSRF.getToken(preRequestLocalSessionState.lastAccessTokenUpdate);
-                if (antiCsrfToken !== undefined) {
-                    logDebugMessage("doRequest: Adding anti-csrf token to request");
-                    configWithAntiCsrf = Object.assign(Object.assign({}, configWithAntiCsrf), {
-                        headers:
-                            configWithAntiCsrf === undefined
-                                ? {
-                                      "anti-csrf": antiCsrfToken
-                                  }
-                                : Object.assign(Object.assign({}, configWithAntiCsrf.headers), {
-                                      "anti-csrf": antiCsrfToken
-                                  })
-                    });
-                }
-            }
-            if (AuthHttpRequestFetch.config.autoAddCredentials && configWithAntiCsrf.withCredentials === undefined) {
-                logDebugMessage("doRequest: Adding credentials include");
-                configWithAntiCsrf = Object.assign(Object.assign({}, configWithAntiCsrf), { withCredentials: true });
-            }
-            // adding rid for anti-csrf protection: Anti-csrf via custom header
-            logDebugMessage("doRequest: Adding rid header: anti-csrf (May get overriden by user's rid)");
-            configWithAntiCsrf = Object.assign(Object.assign({}, configWithAntiCsrf), {
-                headers:
-                    configWithAntiCsrf === undefined
+        return yield httpCall(config);
+    }
+    logDebugMessage("doRequest: Interception started");
+    config = yield removeAuthHeaderIfMatchesLocalToken(config);
+    let returnObj = undefined;
+    while (true) {
+        // we read this here so that if there is a session expiry error, then we can compare this value (that caused the error) with the value after the request is sent.
+        // to avoid race conditions
+        const preRequestLocalSessionState = yield getLocalSessionState();
+        let configWithAntiCsrf = config;
+        if (preRequestLocalSessionState.status === "EXISTS") {
+            const antiCsrfToken = yield AntiCSRF.getToken(preRequestLocalSessionState.lastAccessTokenUpdate);
+            if (antiCsrfToken !== undefined) {
+                logDebugMessage("doRequest: Adding anti-csrf token to request");
+                configWithAntiCsrf = Object.assign(Object.assign({}, configWithAntiCsrf), { headers: configWithAntiCsrf === undefined
                         ? {
-                              rid: "anti-csrf"
-                          }
-                        : Object.assign({ rid: "anti-csrf" }, configWithAntiCsrf.headers)
-            });
-            const transferMethod = AuthHttpRequestFetch.config.tokenTransferMethod;
-            logDebugMessage("doRequest: Adding st-auth-mode header: " + transferMethod);
-            configWithAntiCsrf.headers["st-auth-mode"] = transferMethod;
-            yield setAuthorizationHeaderIfRequired(configWithAntiCsrf);
-            try {
-                let localPrevError = prevError;
-                let localPrevResponse = prevResponse;
-                prevError = undefined;
-                prevResponse = undefined;
-                if (localPrevError !== undefined) {
-                    logDebugMessage("doRequest: Not making call because localPrevError is not undefined");
-                    throw localPrevError;
+                            "anti-csrf": antiCsrfToken
+                        }
+                        : Object.assign(Object.assign({}, configWithAntiCsrf.headers), { "anti-csrf": antiCsrfToken }) });
+            }
+        }
+        if (AuthHttpRequestFetch.config.autoAddCredentials && configWithAntiCsrf.withCredentials === undefined) {
+            logDebugMessage("doRequest: Adding credentials include");
+            configWithAntiCsrf = Object.assign(Object.assign({}, configWithAntiCsrf), { withCredentials: true });
+        }
+        // adding rid for anti-csrf protection: Anti-csrf via custom header
+        logDebugMessage("doRequest: Adding rid header: anti-csrf (May get overriden by user's rid)");
+        configWithAntiCsrf = Object.assign(Object.assign({}, configWithAntiCsrf), { headers: configWithAntiCsrf === undefined
+                ? {
+                    rid: "anti-csrf"
                 }
-                if (localPrevResponse !== undefined) {
-                    logDebugMessage("doRequest: Not making call because localPrevResponse is not undefined");
-                } else {
-                    logDebugMessage("doRequest: Making user's http call");
-                }
-                let response = localPrevResponse === undefined ? yield httpCall(configWithAntiCsrf) : localPrevResponse;
-                // NOTE: No need to check for unauthorized response status here for session refresh,
-                // as we only reach this point on a successful response. Axios handles error responses
-                // by throwing an error, which is handled in the catch block.
-                logDebugMessage("doRequest: User's http call ended");
+                : Object.assign({ rid: "anti-csrf" }, configWithAntiCsrf.headers) });
+        const transferMethod = AuthHttpRequestFetch.config.tokenTransferMethod;
+        logDebugMessage("doRequest: Adding st-auth-mode header: " + transferMethod);
+        configWithAntiCsrf.headers["st-auth-mode"] = transferMethod;
+        yield setAuthorizationHeaderIfRequired(configWithAntiCsrf);
+        try {
+            let localPrevError = prevError;
+            let localPrevResponse = prevResponse;
+            prevError = undefined;
+            prevResponse = undefined;
+            if (localPrevError !== undefined) {
+                logDebugMessage("doRequest: Not making call because localPrevError is not undefined");
+                throw localPrevError;
+            }
+            if (localPrevResponse !== undefined) {
+                logDebugMessage("doRequest: Not making call because localPrevResponse is not undefined");
+            }
+            else {
+                logDebugMessage("doRequest: Making user's http call");
+            }
+            let response = localPrevResponse === undefined ? yield httpCall(configWithAntiCsrf) : localPrevResponse;
+            // NOTE: No need to check for unauthorized response status here for session refresh,
+            // as we only reach this point on a successful response. Axios handles error responses
+            // by throwing an error, which is handled in the catch block.
+            logDebugMessage("doRequest: User's http call ended");
+            yield saveTokensFromHeaders(response);
+            fireSessionUpdateEventsIfNecessary(preRequestLocalSessionState.status === "EXISTS", response.status, response.headers["front-token"]);
+            return response;
+        }
+        catch (err) {
+            const response = err.response;
+            if (response !== undefined) {
                 yield saveTokensFromHeaders(response);
-                fireSessionUpdateEventsIfNecessary(
-                    preRequestLocalSessionState.status === "EXISTS",
-                    response.status,
-                    response.headers["front-token"]
-                );
-                return response;
-            } catch (err) {
-                const response = err.response;
-                if (response !== undefined) {
-                    yield saveTokensFromHeaders(response);
-                    fireSessionUpdateEventsIfNecessary(
-                        preRequestLocalSessionState.status === "EXISTS",
-                        response.status,
-                        response.headers["front-token"]
-                    );
-                    if (err.response.status === AuthHttpRequestFetch.config.sessionExpiredStatusCode) {
-                        logDebugMessage("doRequest: Status code is: " + response.status);
-                        /**
-                         * An API may return a 401 error response even with a valid session, causing a session refresh loop in the interceptor.
-                         * To prevent this infinite loop, we break out of the loop after retrying the original request a specified number of times.
-                         * The maximum number of retry attempts is defined by maxRetryAttemptsForSessionRefresh config variable.
-                         */
-                        if (hasExceededMaxSessionRefreshAttempts(config)) {
-                            logDebugMessage(
-                                `doRequest: Maximum session refresh attempts reached. sessionRefreshAttempts: ${config.__supertokensSessionRefreshAttempts}, maxRetryAttemptsForSessionRefresh: ${AuthHttpRequestFetch.config.maxRetryAttemptsForSessionRefresh}`
-                            );
-                            throw new Error(
-                                `Received a 401 response from ${url}. Attempted to refresh the session and retry the request with the updated session tokens ${AuthHttpRequestFetch.config.maxRetryAttemptsForSessionRefresh} times, but each attempt resulted in a 401 error. The maximum session refresh limit has been reached. Please investigate your API. To increase the session refresh attempts, update maxRetryAttemptsForSessionRefresh in the config.`
-                            );
-                        }
-                        const refreshResult = yield onUnauthorisedResponse(preRequestLocalSessionState);
-                        incrementSessionRefreshAttemptCount(config);
-                        logDebugMessage(
-                            "doRequest: sessionRefreshAttempts: " + config.__supertokensSessionRefreshAttempts
-                        );
-                        if (refreshResult.result !== "RETRY") {
-                            logDebugMessage("doRequest: Not retrying original request");
-                            // Returning refreshResult.error as an Axios Error if we attempted a refresh
-                            // Returning the original error if we did not attempt refreshing
-                            returnObj =
-                                refreshResult.error !== undefined
-                                    ? yield createAxiosErrorFromFetchResp(refreshResult.error)
-                                    : err;
-                            break;
-                        }
-                        logDebugMessage("doRequest: Retrying original request");
-                    } else {
-                        throw err;
+                fireSessionUpdateEventsIfNecessary(preRequestLocalSessionState.status === "EXISTS", response.status, response.headers["front-token"]);
+                if (err.response.status === AuthHttpRequestFetch.config.sessionExpiredStatusCode) {
+                    logDebugMessage("doRequest: Status code is: " + response.status);
+                    /**
+                     * An API may return a 401 error response even with a valid session, causing a session refresh loop in the interceptor.
+                     * To prevent this infinite loop, we break out of the loop after retrying the original request a specified number of times.
+                     * The maximum number of retry attempts is defined by maxRetryAttemptsForSessionRefresh config variable.
+                     */
+                    if (hasExceededMaxSessionRefreshAttempts(config)) {
+                        logDebugMessage(`doRequest: Maximum session refresh attempts reached. sessionRefreshAttempts: ${config.__supertokensSessionRefreshAttempts}, maxRetryAttemptsForSessionRefresh: ${AuthHttpRequestFetch.config.maxRetryAttemptsForSessionRefresh}`);
+                        throw new Error(`Received a 401 response from ${url}. Attempted to refresh the session and retry the request with the updated session tokens ${AuthHttpRequestFetch.config.maxRetryAttemptsForSessionRefresh} times, but each attempt resulted in a 401 error. The maximum session refresh limit has been reached. Please investigate your API. To increase the session refresh attempts, update maxRetryAttemptsForSessionRefresh in the config.`);
                     }
-                } else {
+                    const refreshResult = yield onUnauthorisedResponse(preRequestLocalSessionState);
+                    incrementSessionRefreshAttemptCount(config);
+                    logDebugMessage("doRequest: sessionRefreshAttempts: " + config.__supertokensSessionRefreshAttempts);
+                    if (refreshResult.result !== "RETRY") {
+                        logDebugMessage("doRequest: Not retrying original request");
+                        // Returning refreshResult.error as an Axios Error if we attempted a refresh
+                        // Returning the original error if we did not attempt refreshing
+                        returnObj =
+                            refreshResult.error !== undefined
+                                ? yield createAxiosErrorFromFetchResp(refreshResult.error)
+                                : err;
+                        break;
+                    }
+                    logDebugMessage("doRequest: Retrying original request");
+                }
+                else {
                     throw err;
                 }
             }
+            else {
+                throw err;
+            }
         }
-        // if it comes here, means we called break. which happens only if we have logged out.
-        // which means it's a 401, so we throw
-        throw returnObj;
-    });
+    }
+    // if it comes here, means we called break. which happens only if we have logged out.
+    // which means it's a 401, so we throw
+    throw returnObj;
+});
 function saveTokensFromHeaders(response) {
-    return __awaiter(this, void 0, void 0, function*() {
+    return __awaiter(this, void 0, void 0, function* () {
         logDebugMessage("saveTokensFromHeaders: Saving updated tokens from the response");
         const refreshToken = response.headers["st-refresh-token"];
         if (refreshToken !== undefined && refreshToken !== null) {
@@ -413,7 +337,7 @@ function saveTokensFromHeaders(response) {
     });
 }
 function setAuthorizationHeaderIfRequired(requestConfig) {
-    return __awaiter(this, void 0, void 0, function*() {
+    return __awaiter(this, void 0, void 0, function* () {
         if (requestConfig.headers === undefined) {
             // This is makes TS happy
             requestConfig.headers = {};
@@ -428,27 +352,23 @@ function setAuthorizationHeaderIfRequired(requestConfig) {
         // Still, we only add the Authorization header if both are present, because we are planning to add an option to expose the
         // access token to the frontend while using cookie based auth - so that users can get the access token to use
         if (accessToken !== undefined && refreshToken !== undefined) {
-            if (
-                requestConfig.headers["Authorization"] !== undefined ||
-                requestConfig.headers["authorization"] !== undefined
-            ) {
-                logDebugMessage(
-                    "setAuthorizationHeaderIfRequired: Authorization header defined by the user, not adding"
-                );
-            } else {
+            if (requestConfig.headers["Authorization"] !== undefined ||
+                requestConfig.headers["authorization"] !== undefined) {
+                logDebugMessage("setAuthorizationHeaderIfRequired: Authorization header defined by the user, not adding");
+            }
+            else {
                 logDebugMessage("setAuthorizationHeaderIfRequired: added authorization header");
-                requestConfig.headers = Object.assign(Object.assign({}, requestConfig.headers), {
-                    Authorization: `Bearer ${accessToken}`
-                });
+                requestConfig.headers = Object.assign(Object.assign({}, requestConfig.headers), { Authorization: `Bearer ${accessToken}` });
                 requestConfig.__supertokensAddedAuthHeader = true;
             }
-        } else {
+        }
+        else {
             logDebugMessage("setAuthorizationHeaderIfRequired: token for header based auth not found");
         }
     });
 }
 function removeAuthHeaderIfMatchesLocalToken(config) {
-    return __awaiter(this, void 0, void 0, function*() {
+    return __awaiter(this, void 0, void 0, function* () {
         const accessToken = yield getTokenForHeaderAuth("access");
         const refreshToken = yield getTokenForHeaderAuth("refresh");
         const authHeader = config.headers.Authorization || config.headers.authorization;
@@ -457,9 +377,7 @@ function removeAuthHeaderIfMatchesLocalToken(config) {
                 // We are ignoring the Authorization header set by the user in this case, because it would cause issues
                 // If we do not ignore this, then this header would be used even if the request is being retried after a refresh, even though it contains an outdated access token.
                 // This causes an infinite refresh loop.
-                logDebugMessage(
-                    "removeAuthHeaderIfMatchesLocalToken: Removing Authorization from user provided headers because it contains our access token"
-                );
+                logDebugMessage("removeAuthHeaderIfMatchesLocalToken: Removing Authorization from user provided headers because it contains our access token");
                 const res = Object.assign(Object.assign({}, config), { headers: Object.assign({}, config.headers) });
                 delete res.headers.authorization;
                 delete res.headers.Authorization;

--- a/lib/build/axiosError.js
+++ b/lib/build/axiosError.js
@@ -1,34 +1,12 @@
-var __awaiter =
-    (this && this.__awaiter) ||
-    function(thisArg, _arguments, P, generator) {
-        function adopt(value) {
-            return value instanceof P
-                ? value
-                : new P(function(resolve) {
-                      resolve(value);
-                  });
-        }
-        return new (P || (P = Promise))(function(resolve, reject) {
-            function fulfilled(value) {
-                try {
-                    step(generator.next(value));
-                } catch (e) {
-                    reject(e);
-                }
-            }
-            function rejected(value) {
-                try {
-                    step(generator["throw"](value));
-                } catch (e) {
-                    reject(e);
-                }
-            }
-            function step(result) {
-                result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
-            }
-            step((generator = generator.apply(thisArg, _arguments || [])).next());
-        });
-    };
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
 /**
  * From axios package
  * Update an Error with the specified config, error code, and response.
@@ -69,7 +47,7 @@ function enhanceAxiosError(error, config, code, request, response) {
     return error;
 }
 export function createAxiosErrorFromFetchResp(responseOrError) {
-    return __awaiter(this, void 0, void 0, function*() {
+    return __awaiter(this, void 0, void 0, function* () {
         const config = {
             url: responseOrError.url,
             headers: responseOrError.headers
@@ -82,12 +60,15 @@ export function createAxiosErrorFromFetchResp(responseOrError) {
             if (!contentType || contentType.includes("application/json")) {
                 try {
                     data = yield responseOrError.json();
-                } catch (_a) {
+                }
+                catch (_a) {
                     data = yield responseOrError.text();
                 }
-            } else if (contentType.includes("text/")) {
+            }
+            else if (contentType.includes("text/")) {
                 data = yield responseOrError.text();
-            } else {
+            }
+            else {
                 data = yield responseOrError.blob();
             }
             axiosResponse = {
@@ -99,14 +80,8 @@ export function createAxiosErrorFromFetchResp(responseOrError) {
                 request: undefined
             };
         }
-        return enhanceAxiosError(
-            "status" in responseOrError
-                ? new Error("Request failed with status code " + responseOrError.status)
-                : responseOrError,
-            config,
-            responseOrError.code,
-            undefined,
-            axiosResponse
-        );
+        return enhanceAxiosError("status" in responseOrError
+            ? new Error("Request failed with status code " + responseOrError.status)
+            : responseOrError, config, responseOrError.code, undefined, axiosResponse);
     });
 }

--- a/lib/build/fetch.js
+++ b/lib/build/fetch.js
@@ -12,48 +12,21 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-var __awaiter =
-    (this && this.__awaiter) ||
-    function(thisArg, _arguments, P, generator) {
-        function adopt(value) {
-            return value instanceof P
-                ? value
-                : new P(function(resolve) {
-                      resolve(value);
-                  });
-        }
-        return new (P || (P = Promise))(function(resolve, reject) {
-            function fulfilled(value) {
-                try {
-                    step(generator.next(value));
-                } catch (e) {
-                    reject(e);
-                }
-            }
-            function rejected(value) {
-                try {
-                    step(generator["throw"](value));
-                } catch (e) {
-                    reject(e);
-                }
-            }
-            function step(result) {
-                result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
-            }
-            step((generator = generator.apply(thisArg, _arguments || [])).next());
-        });
-    };
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var _a;
 import { PROCESS_STATE, ProcessState } from "./processState";
 import { supported_fdi } from "./version";
 import AntiCSRF from "./antiCsrf";
 import getLock from "./locking";
-import {
-    fireSessionUpdateEventsIfNecessary,
-    getLocalSessionState,
-    getTokenForHeaderAuth,
-    setToken,
-    validateAndNormaliseInputOrThrowError
-} from "./utils";
+import { fireSessionUpdateEventsIfNecessary, getLocalSessionState, getTokenForHeaderAuth, setToken, validateAndNormaliseInputOrThrowError } from "./utils";
 import FrontToken from "./frontToken";
 import RecipeImplementation from "./recipeImplementation";
 import OverrideableBuilder from "supertokens-js-override";
@@ -93,15 +66,13 @@ export default class AuthHttpRequest {
                     .override(this.config.override.functions)
                     .build();
             }
-            AuthHttpRequest.env.fetch = AuthHttpRequest.env.__supertokensSessionRecipe.addFetchInterceptorsAndReturnModifiedFetch(
-                AuthHttpRequest.env.__supertokensOriginalFetch,
-                config
-            );
+            AuthHttpRequest.env.fetch = AuthHttpRequest.env.__supertokensSessionRecipe.addFetchInterceptorsAndReturnModifiedFetch(AuthHttpRequest.env.__supertokensOriginalFetch, config);
         }
         AuthHttpRequest.recipeImpl = AuthHttpRequest.env.__supertokensSessionRecipe;
         AuthHttpRequest.initCalled = true;
     }
 }
+_a = AuthHttpRequest;
 AuthHttpRequest.initCalled = false;
 /**
  * @description sends the actual http request and returns a response if successful/
@@ -109,152 +80,130 @@ AuthHttpRequest.initCalled = false;
  * attempts to call the refresh token API and if that is successful, calls this API again.
  * @throws Error
  */
-AuthHttpRequest.doRequest = (httpCall, config, url) =>
-    __awaiter(void 0, void 0, void 0, function*() {
-        if (!AuthHttpRequest.initCalled) {
-            throw Error("init function not called");
-        }
-        logDebugMessage("doRequest: start of fetch interception");
-        let doNotDoInterception = false;
-        try {
-            doNotDoInterception =
-                (typeof url === "string" &&
-                    !AuthHttpRequest.recipeImpl.shouldDoInterceptionBasedOnUrl(
-                        url,
-                        AuthHttpRequest.config.apiDomain,
-                        AuthHttpRequest.config.sessionTokenBackendDomain
-                    )) ||
+AuthHttpRequest.doRequest = (httpCall, config, url) => __awaiter(void 0, void 0, void 0, function* () {
+    if (!AuthHttpRequest.initCalled) {
+        throw Error("init function not called");
+    }
+    logDebugMessage("doRequest: start of fetch interception");
+    let doNotDoInterception = false;
+    try {
+        doNotDoInterception =
+            (typeof url === "string" &&
+                !AuthHttpRequest.recipeImpl.shouldDoInterceptionBasedOnUrl(url, AuthHttpRequest.config.apiDomain, AuthHttpRequest.config.sessionTokenBackendDomain)) ||
                 (url !== undefined &&
-                typeof url.url === "string" && // this is because url can be an object like {method: ..., url: ...}
-                    !AuthHttpRequest.recipeImpl.shouldDoInterceptionBasedOnUrl(
-                        url.url,
-                        AuthHttpRequest.config.apiDomain,
-                        AuthHttpRequest.config.sessionTokenBackendDomain
-                    ));
-        } catch (err) {
-            // This is because in react native it is not possible to call fetch with only a path (Example fetch("/login"))
-            // so we dont need to check for that here
-            throw err;
+                    typeof url.url === "string" && // this is because url can be an object like {method: ..., url: ...}
+                    !AuthHttpRequest.recipeImpl.shouldDoInterceptionBasedOnUrl(url.url, AuthHttpRequest.config.apiDomain, AuthHttpRequest.config.sessionTokenBackendDomain));
+    }
+    catch (err) {
+        // This is because in react native it is not possible to call fetch with only a path (Example fetch("/login"))
+        // so we dont need to check for that here
+        throw err;
+    }
+    logDebugMessage("doRequest: Value of doNotDoInterception: " + doNotDoInterception);
+    if (doNotDoInterception) {
+        logDebugMessage("doRequest: Returning without interception");
+        return yield httpCall(config);
+    }
+    const originalHeaders = new Headers(config !== undefined && config.headers !== undefined ? config.headers : url.headers);
+    if (originalHeaders.has("Authorization")) {
+        const accessToken = yield getTokenForHeaderAuth("access");
+        const refreshToken = yield getTokenForHeaderAuth("refresh");
+        if (accessToken !== undefined &&
+            refreshToken !== undefined &&
+            originalHeaders.get("Authorization") === `Bearer ${accessToken}`) {
+            // We are ignoring the Authorization header set by the user in this case, because it would cause issues
+            // If we do not ignore this, then this header would be used even if the request is being retried after a refresh, even though it contains an outdated access token.
+            // This causes an infinite refresh loop.
+            logDebugMessage("doRequest: Removing Authorization from user provided headers because it contains our access token");
+            originalHeaders.delete("Authorization");
         }
-        logDebugMessage("doRequest: Value of doNotDoInterception: " + doNotDoInterception);
-        if (doNotDoInterception) {
-            logDebugMessage("doRequest: Returning without interception");
-            return yield httpCall(config);
-        }
-        const originalHeaders = new Headers(
-            config !== undefined && config.headers !== undefined ? config.headers : url.headers
-        );
-        if (originalHeaders.has("Authorization")) {
-            const accessToken = yield getTokenForHeaderAuth("access");
-            const refreshToken = yield getTokenForHeaderAuth("refresh");
-            if (
-                accessToken !== undefined &&
-                refreshToken !== undefined &&
-                originalHeaders.get("Authorization") === `Bearer ${accessToken}`
-            ) {
-                // We are ignoring the Authorization header set by the user in this case, because it would cause issues
-                // If we do not ignore this, then this header would be used even if the request is being retried after a refresh, even though it contains an outdated access token.
-                // This causes an infinite refresh loop.
-                logDebugMessage(
-                    "doRequest: Removing Authorization from user provided headers because it contains our access token"
-                );
-                originalHeaders.delete("Authorization");
-            }
-        }
-        logDebugMessage("doRequest: Interception started");
-        ProcessState.getInstance().addState(PROCESS_STATE.CALLING_INTERCEPTION_REQUEST);
-        let sessionRefreshAttempts = 0;
-        let returnObj = undefined;
-        while (true) {
-            // we read this here so that if there is a session expiry error, then we can compare this value (that caused the error) with the value after the request is sent.
-            // to avoid race conditions
-            const preRequestLocalSessionState = yield getLocalSessionState();
-            const clonedHeaders = new Headers(originalHeaders);
-            let configWithAntiCsrf = Object.assign(Object.assign({}, config), { headers: clonedHeaders });
-            if (preRequestLocalSessionState.status === "EXISTS") {
-                const antiCsrfToken = yield AntiCSRF.getToken(preRequestLocalSessionState.lastAccessTokenUpdate);
-                if (antiCsrfToken !== undefined) {
-                    logDebugMessage("doRequest: Adding anti-csrf token to request");
-                    clonedHeaders.set("anti-csrf", antiCsrfToken);
-                }
-            }
-            if (AuthHttpRequest.config.autoAddCredentials) {
-                logDebugMessage("doRequest: Adding credentials include");
-                if (configWithAntiCsrf === undefined) {
-                    configWithAntiCsrf = {
-                        credentials: "include"
-                    };
-                } else if (configWithAntiCsrf.credentials === undefined) {
-                    configWithAntiCsrf = Object.assign(Object.assign({}, configWithAntiCsrf), {
-                        credentials: "include"
-                    });
-                }
-            }
-            // adding rid for anti-csrf protection: Anti-csrf via custom header
-            if (!clonedHeaders.has("rid")) {
-                logDebugMessage("doRequest: Adding rid header: anti-csrf");
-                clonedHeaders.set("rid", "anti-csrf");
-            } else {
-                logDebugMessage("doRequest: rid header was already there in request");
-            }
-            const transferMethod = AuthHttpRequest.config.tokenTransferMethod;
-            logDebugMessage("doRequest: Adding st-auth-mode header: " + transferMethod);
-            clonedHeaders.set("st-auth-mode", transferMethod);
-            yield setAuthorizationHeaderIfRequired(clonedHeaders);
-            logDebugMessage("doRequest: Making user's http call");
-            let response = yield httpCall(configWithAntiCsrf);
-            logDebugMessage("doRequest: User's http call ended");
-            yield saveTokensFromHeaders(response);
-            fireSessionUpdateEventsIfNecessary(
-                preRequestLocalSessionState.status === "EXISTS",
-                response.status,
-                response.headers.get("front-token")
-            );
-            if (response.status === AuthHttpRequest.config.sessionExpiredStatusCode) {
-                logDebugMessage("doRequest: Status code is: " + response.status);
-                /**
-                 * An API may return a 401 error response even with a valid session, causing a session refresh loop in the interceptor.
-                 * To prevent this infinite loop, we break out of the loop after retrying the original request a specified number of times.
-                 * The maximum number of retry attempts is defined by maxRetryAttemptsForSessionRefresh config variable.
-                 */
-                if (sessionRefreshAttempts >= AuthHttpRequest.config.maxRetryAttemptsForSessionRefresh) {
-                    logDebugMessage(
-                        `doRequest: Maximum session refresh attempts reached. sessionRefreshAttempts: ${sessionRefreshAttempts}, maxRetryAttemptsForSessionRefresh: ${AuthHttpRequest.config.maxRetryAttemptsForSessionRefresh}`
-                    );
-                    throw new Error(
-                        `Received a 401 response from ${url}. Attempted to refresh the session and retry the request with the updated session tokens ${AuthHttpRequest.config.maxRetryAttemptsForSessionRefresh} times, but each attempt resulted in a 401 error. The maximum session refresh limit has been reached. Please investigate your API. To increase the session refresh attempts, update maxRetryAttemptsForSessionRefresh in the config.`
-                    );
-                }
-                let refreshResponse = yield onUnauthorisedResponse(preRequestLocalSessionState);
-                sessionRefreshAttempts++;
-                logDebugMessage("doRequest: sessionRefreshAttempts: " + sessionRefreshAttempts);
-                if (refreshResponse.result !== "RETRY") {
-                    logDebugMessage("doRequest: Not retrying original request");
-                    returnObj = refreshResponse.error !== undefined ? refreshResponse.error : response;
-                    break;
-                }
-            } else {
-                return response;
-            }
-        }
-        // if it comes here, means we breaked. which happens only if we have logged out.
-        return returnObj;
-    });
-AuthHttpRequest.attemptRefreshingSession = () =>
-    __awaiter(void 0, void 0, void 0, function*() {
-        if (!AuthHttpRequest.initCalled) {
-            throw new Error("init function not called");
-        }
+    }
+    logDebugMessage("doRequest: Interception started");
+    ProcessState.getInstance().addState(PROCESS_STATE.CALLING_INTERCEPTION_REQUEST);
+    let sessionRefreshAttempts = 0;
+    let returnObj = undefined;
+    while (true) {
+        // we read this here so that if there is a session expiry error, then we can compare this value (that caused the error) with the value after the request is sent.
+        // to avoid race conditions
         const preRequestLocalSessionState = yield getLocalSessionState();
-        const refreshResponse = yield onUnauthorisedResponse(preRequestLocalSessionState);
-        if (refreshResponse.result === "API_ERROR") {
-            throw refreshResponse.error;
+        const clonedHeaders = new Headers(originalHeaders);
+        let configWithAntiCsrf = Object.assign(Object.assign({}, config), { headers: clonedHeaders });
+        if (preRequestLocalSessionState.status === "EXISTS") {
+            const antiCsrfToken = yield AntiCSRF.getToken(preRequestLocalSessionState.lastAccessTokenUpdate);
+            if (antiCsrfToken !== undefined) {
+                logDebugMessage("doRequest: Adding anti-csrf token to request");
+                clonedHeaders.set("anti-csrf", antiCsrfToken);
+            }
         }
-        return refreshResponse.result === "RETRY";
-    });
+        if (AuthHttpRequest.config.autoAddCredentials) {
+            logDebugMessage("doRequest: Adding credentials include");
+            if (configWithAntiCsrf === undefined) {
+                configWithAntiCsrf = {
+                    credentials: "include"
+                };
+            }
+            else if (configWithAntiCsrf.credentials === undefined) {
+                configWithAntiCsrf = Object.assign(Object.assign({}, configWithAntiCsrf), { credentials: "include" });
+            }
+        }
+        // adding rid for anti-csrf protection: Anti-csrf via custom header
+        if (!clonedHeaders.has("rid")) {
+            logDebugMessage("doRequest: Adding rid header: anti-csrf");
+            clonedHeaders.set("rid", "anti-csrf");
+        }
+        else {
+            logDebugMessage("doRequest: rid header was already there in request");
+        }
+        const transferMethod = AuthHttpRequest.config.tokenTransferMethod;
+        logDebugMessage("doRequest: Adding st-auth-mode header: " + transferMethod);
+        clonedHeaders.set("st-auth-mode", transferMethod);
+        yield setAuthorizationHeaderIfRequired(clonedHeaders);
+        logDebugMessage("doRequest: Making user's http call");
+        let response = yield httpCall(configWithAntiCsrf);
+        logDebugMessage("doRequest: User's http call ended");
+        yield saveTokensFromHeaders(response);
+        fireSessionUpdateEventsIfNecessary(preRequestLocalSessionState.status === "EXISTS", response.status, response.headers.get("front-token"));
+        if (response.status === AuthHttpRequest.config.sessionExpiredStatusCode) {
+            logDebugMessage("doRequest: Status code is: " + response.status);
+            /**
+             * An API may return a 401 error response even with a valid session, causing a session refresh loop in the interceptor.
+             * To prevent this infinite loop, we break out of the loop after retrying the original request a specified number of times.
+             * The maximum number of retry attempts is defined by maxRetryAttemptsForSessionRefresh config variable.
+             */
+            if (sessionRefreshAttempts >= AuthHttpRequest.config.maxRetryAttemptsForSessionRefresh) {
+                logDebugMessage(`doRequest: Maximum session refresh attempts reached. sessionRefreshAttempts: ${sessionRefreshAttempts}, maxRetryAttemptsForSessionRefresh: ${AuthHttpRequest.config.maxRetryAttemptsForSessionRefresh}`);
+                throw new Error(`Received a 401 response from ${url}. Attempted to refresh the session and retry the request with the updated session tokens ${AuthHttpRequest.config.maxRetryAttemptsForSessionRefresh} times, but each attempt resulted in a 401 error. The maximum session refresh limit has been reached. Please investigate your API. To increase the session refresh attempts, update maxRetryAttemptsForSessionRefresh in the config.`);
+            }
+            let refreshResponse = yield onUnauthorisedResponse(preRequestLocalSessionState);
+            sessionRefreshAttempts++;
+            logDebugMessage("doRequest: sessionRefreshAttempts: " + sessionRefreshAttempts);
+            if (refreshResponse.result !== "RETRY") {
+                logDebugMessage("doRequest: Not retrying original request");
+                returnObj = refreshResponse.error !== undefined ? refreshResponse.error : response;
+                break;
+            }
+        }
+        else {
+            return response;
+        }
+    }
+    // if it comes here, means we breaked. which happens only if we have logged out.
+    return returnObj;
+});
+AuthHttpRequest.attemptRefreshingSession = () => __awaiter(void 0, void 0, void 0, function* () {
+    if (!AuthHttpRequest.initCalled) {
+        throw new Error("init function not called");
+    }
+    const preRequestLocalSessionState = yield getLocalSessionState();
+    const refreshResponse = yield onUnauthorisedResponse(preRequestLocalSessionState);
+    if (refreshResponse.result === "API_ERROR") {
+        throw refreshResponse.error;
+    }
+    return refreshResponse.result === "RETRY";
+});
 const LOCK_NAME = "REFRESH_TOKEN_USE";
 export function onUnauthorisedResponse(preRequestLocalSessionState) {
-    return __awaiter(this, void 0, void 0, function*() {
+    return __awaiter(this, void 0, void 0, function* () {
         let lock = getLock();
         logDebugMessage("onUnauthorisedResponse: trying to acquire lock");
         yield lock.lock(LOCK_NAME);
@@ -271,16 +220,11 @@ export function onUnauthorisedResponse(preRequestLocalSessionState) {
                 });
                 return { result: "SESSION_EXPIRED" };
             }
-            if (
-                postLockLocalSessionState.status !== preRequestLocalSessionState.status ||
+            if (postLockLocalSessionState.status !== preRequestLocalSessionState.status ||
                 (postLockLocalSessionState.status === "EXISTS" &&
                     preRequestLocalSessionState.status === "EXISTS" &&
-                    postLockLocalSessionState.lastAccessTokenUpdate !==
-                        preRequestLocalSessionState.lastAccessTokenUpdate)
-            ) {
-                logDebugMessage(
-                    "onUnauthorisedResponse: Retrying early because pre and post lastAccessTokenUpdate don't match"
-                );
+                    postLockLocalSessionState.lastAccessTokenUpdate !== preRequestLocalSessionState.lastAccessTokenUpdate)) {
+                logDebugMessage("onUnauthorisedResponse: Retrying early because pre and post lastAccessTokenUpdate don't match");
                 // means that some other process has already called this API and succeeded. so we need to call it again
                 return { result: "RETRY" };
             }
@@ -310,10 +254,7 @@ export function onUnauthorisedResponse(preRequestLocalSessionState) {
                 url: AuthHttpRequest.refreshTokenUrl
             });
             logDebugMessage("onUnauthorisedResponse: Making refresh call");
-            const response = yield AuthHttpRequest.env.__supertokensOriginalFetch(
-                preAPIResult.url,
-                preAPIResult.requestInit
-            );
+            const response = yield AuthHttpRequest.env.__supertokensOriginalFetch(preAPIResult.url, preAPIResult.requestInit);
             logDebugMessage("onUnauthorisedResponse: Refresh call ended");
             yield saveTokensFromHeaders(response);
             logDebugMessage("onUnauthorisedResponse: Refresh status code is: " + response.status);
@@ -323,13 +264,9 @@ export function onUnauthorisedResponse(preRequestLocalSessionState) {
             if (isUnauthorised && response.headers.get("front-token") === null) {
                 FrontToken.setItem("remove");
             }
-            fireSessionUpdateEventsIfNecessary(
-                preRequestLocalSessionState.status === "EXISTS",
-                response.status,
-                isUnauthorised && response.headers.get("front-token") === null
-                    ? "remove"
-                    : response.headers.get("front-token")
-            );
+            fireSessionUpdateEventsIfNecessary(preRequestLocalSessionState.status === "EXISTS", response.status, isUnauthorised && response.headers.get("front-token") === null
+                ? "remove"
+                : response.headers.get("front-token"));
             if (response.status >= 300) {
                 throw response;
             }
@@ -348,7 +285,8 @@ export function onUnauthorisedResponse(preRequestLocalSessionState) {
             });
             logDebugMessage("onUnauthorisedResponse: Sending RETRY signal");
             return { result: "RETRY" };
-        } catch (error) {
+        }
+        catch (error) {
             if ((yield getLocalSessionState()).status === "NOT_EXISTS") {
                 logDebugMessage("onUnauthorisedResponse: local session doesn't exist, so returning session expired");
                 // removed by server.
@@ -360,14 +298,15 @@ export function onUnauthorisedResponse(preRequestLocalSessionState) {
             }
             logDebugMessage("onUnauthorisedResponse: sending API_ERROR");
             return { result: "API_ERROR", error };
-        } finally {
+        }
+        finally {
             lock.unlock(LOCK_NAME);
             logDebugMessage("onUnauthorisedResponse: Released lock");
         }
     });
 }
 function saveTokensFromHeaders(response) {
-    return __awaiter(this, void 0, void 0, function*() {
+    return __awaiter(this, void 0, void 0, function* () {
         logDebugMessage("saveTokensFromHeaders: Saving updated tokens from the response headers");
         const refreshToken = response.headers.get("st-refresh-token");
         if (refreshToken !== undefined && refreshToken !== null) {
@@ -395,7 +334,7 @@ function saveTokensFromHeaders(response) {
     });
 }
 function setAuthorizationHeaderIfRequired(clonedHeaders, addRefreshToken = false) {
-    return __awaiter(this, void 0, void 0, function*() {
+    return __awaiter(this, void 0, void 0, function* () {
         logDebugMessage("setTokenHeaders: adding existing tokens as header");
         // We set the Authorization header even if the tokenTransferMethod preference set in the config is cookies
         // since the active session may be using cookies. By default, we want to allow users to continue these sessions.
@@ -408,14 +347,14 @@ function setAuthorizationHeaderIfRequired(clonedHeaders, addRefreshToken = false
         if (accessToken !== undefined && refreshToken !== undefined) {
             // the Headers class normalizes header names so we don't have to worry about casing
             if (clonedHeaders.has("Authorization")) {
-                logDebugMessage(
-                    "setAuthorizationHeaderIfRequired: Authorization header defined by the user, not adding"
-                );
-            } else {
+                logDebugMessage("setAuthorizationHeaderIfRequired: Authorization header defined by the user, not adding");
+            }
+            else {
                 clonedHeaders.set("Authorization", `Bearer ${addRefreshToken ? refreshToken : accessToken}`);
                 logDebugMessage("setAuthorizationHeaderIfRequired: added authorization header");
             }
-        } else {
+        }
+        else {
             logDebugMessage("setAuthorizationHeaderIfRequired: token for header based auth not found");
         }
     });

--- a/lib/build/frontToken.js
+++ b/lib/build/frontToken.js
@@ -1,34 +1,12 @@
-var __awaiter =
-    (this && this.__awaiter) ||
-    function(thisArg, _arguments, P, generator) {
-        function adopt(value) {
-            return value instanceof P
-                ? value
-                : new P(function(resolve) {
-                      resolve(value);
-                  });
-        }
-        return new (P || (P = Promise))(function(resolve, reject) {
-            function fulfilled(value) {
-                try {
-                    step(generator.next(value));
-                } catch (e) {
-                    reject(e);
-                }
-            }
-            function rejected(value) {
-                try {
-                    step(generator["throw"](value));
-                } catch (e) {
-                    reject(e);
-                }
-            }
-            function step(result) {
-                result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
-            }
-            step((generator = generator.apply(thisArg, _arguments || [])).next());
-        });
-    };
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import { decode as atob } from "base-64";
 import { getLocalSessionState, saveLastAccessTokenUpdate, setToken } from "./utils";
@@ -37,9 +15,9 @@ import AntiCSRF from "./antiCsrf";
 const FRONT_TOKEN_KEY = "supertokens-rn-front-token-key";
 const FRONT_TOKEN_NAME = "sFrontToken";
 export default class FrontToken {
-    constructor() {}
+    constructor() { }
     static getFrontTokenFromStorage() {
-        return __awaiter(this, void 0, void 0, function*() {
+        return __awaiter(this, void 0, void 0, function* () {
             logDebugMessage("getFrontTokenFromStorage: called");
             let frontTokenFromStorage = yield AsyncStorage.getItem(FRONT_TOKEN_KEY);
             if (frontTokenFromStorage !== null) {
@@ -72,7 +50,7 @@ export default class FrontToken {
         });
     }
     static getFrontToken() {
-        return __awaiter(this, void 0, void 0, function*() {
+        return __awaiter(this, void 0, void 0, function* () {
             logDebugMessage("getFrontToken: called");
             if ((yield getLocalSessionState()).status !== "EXISTS") {
                 logDebugMessage("getFrontToken: Returning because sIRTFrontend != EXISTS");
@@ -84,7 +62,7 @@ export default class FrontToken {
         });
     }
     static getTokenInfo() {
-        return __awaiter(this, void 0, void 0, function*() {
+        return __awaiter(this, void 0, void 0, function* () {
             logDebugMessage("FrontToken.getTokenInfo: called");
             let frontToken = yield this.getFrontToken();
             if (frontToken === null) {
@@ -95,7 +73,8 @@ export default class FrontToken {
                         FrontToken.waiters.push(resolve);
                     });
                     return FrontToken.getTokenInfo();
-                } else {
+                }
+                else {
                     return undefined;
                 }
             }
@@ -107,13 +86,14 @@ export default class FrontToken {
         });
     }
     static setFrontToken(frontToken) {
-        return __awaiter(this, void 0, void 0, function*() {
+        return __awaiter(this, void 0, void 0, function* () {
             logDebugMessage("setFrontToken: called");
             function setFrontTokenToStorage(frontToken) {
-                return __awaiter(this, void 0, void 0, function*() {
+                return __awaiter(this, void 0, void 0, function* () {
                     if (frontToken === undefined) {
                         yield AsyncStorage.removeItem(FRONT_TOKEN_KEY);
-                    } else {
+                    }
+                    else {
                         yield AsyncStorage.setItem(FRONT_TOKEN_KEY, frontToken);
                     }
                 });
@@ -122,7 +102,7 @@ export default class FrontToken {
         });
     }
     static removeToken() {
-        return __awaiter(this, void 0, void 0, function*() {
+        return __awaiter(this, void 0, void 0, function* () {
             logDebugMessage("FrontToken.removeToken: called");
             yield this.setFrontToken(undefined);
             yield setToken("access", "");
@@ -133,7 +113,7 @@ export default class FrontToken {
         });
     }
     static setItem(frontToken) {
-        return __awaiter(this, void 0, void 0, function*() {
+        return __awaiter(this, void 0, void 0, function* () {
             // We update the refresh attempt info here as well, since this means that we've updated the session in some way
             // This could be both by a refresh call or if the access token was updated in a custom endpoint
             // By saving every time the access token has been updated, we cause an early retry if
@@ -151,7 +131,7 @@ export default class FrontToken {
         });
     }
     static doesTokenExists() {
-        return __awaiter(this, void 0, void 0, function*() {
+        return __awaiter(this, void 0, void 0, function* () {
             const frontToken = yield this.getFrontTokenFromStorage();
             return frontToken !== null;
         });

--- a/lib/build/index.js
+++ b/lib/build/index.js
@@ -12,37 +12,16 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-var __awaiter =
-    (this && this.__awaiter) ||
-    function(thisArg, _arguments, P, generator) {
-        function adopt(value) {
-            return value instanceof P
-                ? value
-                : new P(function(resolve) {
-                      resolve(value);
-                  });
-        }
-        return new (P || (P = Promise))(function(resolve, reject) {
-            function fulfilled(value) {
-                try {
-                    step(generator.next(value));
-                } catch (e) {
-                    reject(e);
-                }
-            }
-            function rejected(value) {
-                try {
-                    step(generator["throw"](value));
-                } catch (e) {
-                    reject(e);
-                }
-            }
-            function step(result) {
-                result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
-            }
-            step((generator = generator.apply(thisArg, _arguments || [])).next());
-        });
-    };
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var _a;
 import AuthHttpRequestFetch from "./fetch";
 import { getTokenForHeaderAuth } from "./utils";
 export default class AuthHttpRequest {
@@ -60,7 +39,7 @@ export default class AuthHttpRequest {
         return AuthHttpRequestFetch.recipeImpl.getUserId(AuthHttpRequestFetch.config);
     }
     static getAccessTokenPayloadSecurely() {
-        return __awaiter(this, void 0, void 0, function*() {
+        return __awaiter(this, void 0, void 0, function* () {
             if (!AuthHttpRequestFetch.initCalled) {
                 throw Error("init function not called");
             }
@@ -68,18 +47,18 @@ export default class AuthHttpRequest {
         });
     }
 }
+_a = AuthHttpRequest;
 AuthHttpRequest.axiosInterceptorQueue = [];
-AuthHttpRequest.attemptRefreshingSession = () =>
-    __awaiter(void 0, void 0, void 0, function*() {
-        return AuthHttpRequestFetch.attemptRefreshingSession();
-    });
+AuthHttpRequest.attemptRefreshingSession = () => __awaiter(void 0, void 0, void 0, function* () {
+    return AuthHttpRequestFetch.attemptRefreshingSession();
+});
 AuthHttpRequest.doesSessionExist = () => {
     if (!AuthHttpRequestFetch.initCalled) {
         throw Error("init function not called");
     }
     return AuthHttpRequestFetch.recipeImpl.doesSessionExist(AuthHttpRequestFetch.config);
 };
-AuthHttpRequest.addAxiosInterceptors = axiosInstance => {
+AuthHttpRequest.addAxiosInterceptors = (axiosInstance) => {
     if (!AuthHttpRequestFetch.initCalled) {
         // the recipe implementation has not been initialised yet, so add
         // this to the queue and wait for it to be initialised, and then on
@@ -87,7 +66,8 @@ AuthHttpRequest.addAxiosInterceptors = axiosInstance => {
         AuthHttpRequest.axiosInterceptorQueue.push(() => {
             AuthHttpRequestFetch.recipeImpl.addAxiosInterceptors(axiosInstance, AuthHttpRequestFetch.config);
         });
-    } else {
+    }
+    else {
         AuthHttpRequestFetch.recipeImpl.addAxiosInterceptors(axiosInstance, AuthHttpRequestFetch.config);
     }
 };
@@ -97,17 +77,16 @@ AuthHttpRequest.signOut = () => {
     }
     return AuthHttpRequestFetch.recipeImpl.signOut(AuthHttpRequestFetch.config);
 };
-AuthHttpRequest.getAccessToken = () =>
-    __awaiter(void 0, void 0, void 0, function*() {
-        if (!AuthHttpRequestFetch.initCalled) {
-            throw Error("init function not called");
-        }
-        // This takes care of refreshing the access token if needed
-        if (yield AuthHttpRequestFetch.recipeImpl.doesSessionExist(AuthHttpRequestFetch.config)) {
-            return getTokenForHeaderAuth("access");
-        }
-        return undefined;
-    });
+AuthHttpRequest.getAccessToken = () => __awaiter(void 0, void 0, void 0, function* () {
+    if (!AuthHttpRequestFetch.initCalled) {
+        throw Error("init function not called");
+    }
+    // This takes care of refreshing the access token if needed
+    if (yield AuthHttpRequestFetch.recipeImpl.doesSessionExist(AuthHttpRequestFetch.config)) {
+        return getTokenForHeaderAuth("access");
+    }
+    return undefined;
+});
 export let init = AuthHttpRequest.init;
 export let getUserId = AuthHttpRequest.getUserId;
 export let getAccessTokenPayloadSecurely = AuthHttpRequest.getAccessTokenPayloadSecurely;

--- a/lib/build/locking.js
+++ b/lib/build/locking.js
@@ -24,30 +24,33 @@ class Locking {
             if (callbacks === undefined) {
                 if (toAdd === undefined) {
                     this.locked.set(key, []);
-                } else {
+                }
+                else {
                     this.locked.set(key, [toAdd]);
                 }
-            } else {
+            }
+            else {
                 if (toAdd !== undefined) {
                     callbacks.unshift(toAdd);
                     this.locked.set(key, callbacks);
                 }
             }
         };
-        this.isLocked = key => {
+        this.isLocked = (key) => {
             return this.locked.has(key);
         };
-        this.lock = key => {
+        this.lock = (key) => {
             return new Promise((resolve, reject) => {
                 if (this.isLocked(key)) {
                     this.addToLocked(key, resolve);
-                } else {
+                }
+                else {
                     this.addToLocked(key);
                     resolve();
                 }
             });
         };
-        this.unlock = key => {
+        this.unlock = (key) => {
             let callbacks = this.locked.get(key);
             if (callbacks === undefined || callbacks.length === 0) {
                 this.locked.delete(key);

--- a/lib/build/logger.js
+++ b/lib/build/logger.js
@@ -23,8 +23,6 @@ export function disableLogging() {
 }
 export function logDebugMessage(message) {
     if (__supertokensWebsiteLogging) {
-        console.log(
-            `${SUPERTOKENS_DEBUG_NAMESPACE} {t: "${new Date().toISOString()}", message: \"${message}\", supertokens-react-native: "${version}"}`
-        );
+        console.log(`${SUPERTOKENS_DEBUG_NAMESPACE} {t: "${new Date().toISOString()}", message: \"${message}\", supertokens-react-native: "${version}"}`);
     }
 }

--- a/lib/build/normalisedURLDomain.js
+++ b/lib/build/normalisedURLDomain.js
@@ -33,15 +33,18 @@ function normaliseURLDomainOrThrowError(input, ignoreProtocol = false) {
         if (ignoreProtocol) {
             if (urlObj.hostname.startsWith("localhost") || isAnIpAddress(urlObj.hostname)) {
                 input = "http://" + urlObj.host;
-            } else {
+            }
+            else {
                 input = "https://" + urlObj.host;
             }
-        } else {
+        }
+        else {
             input = urlObj.protocol + "//" + urlObj.host;
         }
         return input;
         // eslint-disable-next-line no-empty
-    } catch (err) {}
+    }
+    catch (err) { }
     if (input.startsWith("/")) {
         throw new Error("Please provide a valid domain name");
     }
@@ -51,11 +54,9 @@ function normaliseURLDomainOrThrowError(input, ignoreProtocol = false) {
     }
     // If the input contains a . it means they have given a domain name.
     // So we try assuming that they have given a domain name
-    if (
-        (input.indexOf(".") !== -1 || input.startsWith("localhost")) &&
+    if ((input.indexOf(".") !== -1 || input.startsWith("localhost")) &&
         !input.startsWith("http://") &&
-        !input.startsWith("https://")
-    ) {
+        !input.startsWith("https://")) {
         input = "https://" + input;
         // at this point, it should be a valid URL. So we test that before doing a recursive call
         try {
@@ -63,7 +64,8 @@ function normaliseURLDomainOrThrowError(input, ignoreProtocol = false) {
             new URL(input);
             return normaliseURLDomainOrThrowError(input, true);
             // eslint-disable-next-line no-empty
-        } catch (err) {}
+        }
+        catch (err) { }
     }
     throw new Error("Please provide a valid domain name");
 }

--- a/lib/build/normalisedURLPath.js
+++ b/lib/build/normalisedURLPath.js
@@ -15,10 +15,10 @@
 import { URL } from "react-native-url-polyfill";
 export default class NormalisedURLPath {
     constructor(url) {
-        this.startsWith = other => {
+        this.startsWith = (other) => {
             return this.value.startsWith(other.value);
         };
-        this.appendPath = other => {
+        this.appendPath = (other) => {
             return new NormalisedURLPath(this.value + other.value);
         };
         this.getAsStringDangerous = () => {
@@ -41,15 +41,14 @@ function normaliseURLPathOrThrowError(input) {
         }
         return input;
         // eslint-disable-next-line no-empty
-    } catch (err) {}
+    }
+    catch (err) { }
     // not a valid URL
     // If the input contains a . it means they have given a domain name.
     // So we try assuming that they have given a domain name + path
-    if (
-        (domainGiven(input) || input.startsWith("localhost")) &&
+    if ((domainGiven(input) || input.startsWith("localhost")) &&
         !input.startsWith("http://") &&
-        !input.startsWith("https://")
-    ) {
+        !input.startsWith("https://")) {
         input = "http://" + input;
         return normaliseURLPathOrThrowError(input);
     }
@@ -62,7 +61,8 @@ function normaliseURLPathOrThrowError(input) {
         // @ts-ignore (Typescript complains that URL does not expect a parameter in constructor even though it does for react-native-url-polyfill)
         new URL("http://example.com" + input);
         return normaliseURLPathOrThrowError("http://example.com" + input);
-    } catch (err) {
+    }
+    catch (err) {
         throw new Error("Please provide a valid URL path");
     }
 }
@@ -75,11 +75,13 @@ function domainGiven(input) {
         // @ts-ignore (Typescript complains that URL does not expect a parameter in constructor even though it does for react-native-url-polyfill)
         const url = new URL(input);
         return url.hostname.indexOf(".") !== -1;
-    } catch (e) {}
+    }
+    catch (e) { }
     try {
         // @ts-ignore (Typescript complains that URL does not expect a parameter in constructor even though it does for react-native-url-polyfill)
         const url = new URL("http://" + input);
         return url.hostname.indexOf(".") !== -1;
-    } catch (e) {}
+    }
+    catch (e) { }
     return false;
 }

--- a/lib/build/processState.js
+++ b/lib/build/processState.js
@@ -12,53 +12,31 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-var __awaiter =
-    (this && this.__awaiter) ||
-    function(thisArg, _arguments, P, generator) {
-        function adopt(value) {
-            return value instanceof P
-                ? value
-                : new P(function(resolve) {
-                      resolve(value);
-                  });
-        }
-        return new (P || (P = Promise))(function(resolve, reject) {
-            function fulfilled(value) {
-                try {
-                    step(generator.next(value));
-                } catch (e) {
-                    reject(e);
-                }
-            }
-            function rejected(value) {
-                try {
-                    step(generator["throw"](value));
-                } catch (e) {
-                    reject(e);
-                }
-            }
-            function step(result) {
-                result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
-            }
-            step((generator = generator.apply(thisArg, _arguments || [])).next());
-        });
-    };
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
 export var PROCESS_STATE;
-(function(PROCESS_STATE) {
+(function (PROCESS_STATE) {
     //CALLING_INTERCEPTION_REQUEST : Process state for the request interceptor.
     //CALLING_INTERCEPTION_RESOPONSE : Process state for the response interceptor.
-    PROCESS_STATE[(PROCESS_STATE["CALLING_INTERCEPTION_REQUEST"] = 0)] = "CALLING_INTERCEPTION_REQUEST";
-    PROCESS_STATE[(PROCESS_STATE["CALLING_INTERCEPTION_RESPONSE"] = 1)] = "CALLING_INTERCEPTION_RESPONSE";
+    PROCESS_STATE[PROCESS_STATE["CALLING_INTERCEPTION_REQUEST"] = 0] = "CALLING_INTERCEPTION_REQUEST";
+    PROCESS_STATE[PROCESS_STATE["CALLING_INTERCEPTION_RESPONSE"] = 1] = "CALLING_INTERCEPTION_RESPONSE";
 })(PROCESS_STATE || (PROCESS_STATE = {}));
 export class ProcessState {
     constructor() {
         this.history = [];
-        this.addState = state => {
+        this.addState = (state) => {
             if (process !== undefined && process.env !== undefined && process.env.TEST_MODE === "testing") {
                 this.history.push(state);
             }
         };
-        this.getEventByLastEventByName = state => {
+        this.getEventByLastEventByName = (state) => {
             for (let i = this.history.length - 1; i >= 0; i--) {
                 if (this.history[i] == state) {
                     return this.history[i];
@@ -69,26 +47,27 @@ export class ProcessState {
         this.reset = () => {
             this.history = [];
         };
-        this.waitForEvent = (state, timeInMS = 7000) =>
-            __awaiter(this, void 0, void 0, function*() {
-                let startTime = Date.now();
-                return new Promise(resolve => {
-                    let actualThis = this;
-                    function tryAndGet() {
-                        let result = actualThis.getEventByLastEventByName(state);
-                        if (result === undefined) {
-                            if (Date.now() - startTime > timeInMS) {
-                                resolve(undefined);
-                            } else {
-                                setTimeout(tryAndGet, 1000);
-                            }
-                        } else {
-                            resolve(result);
+        this.waitForEvent = (state, timeInMS = 7000) => __awaiter(this, void 0, void 0, function* () {
+            let startTime = Date.now();
+            return new Promise(resolve => {
+                let actualThis = this;
+                function tryAndGet() {
+                    let result = actualThis.getEventByLastEventByName(state);
+                    if (result === undefined) {
+                        if (Date.now() - startTime > timeInMS) {
+                            resolve(undefined);
+                        }
+                        else {
+                            setTimeout(tryAndGet, 1000);
                         }
                     }
-                    tryAndGet();
-                });
+                    else {
+                        resolve(result);
+                    }
+                }
+                tryAndGet();
             });
+        });
     }
     static getInstance() {
         if (ProcessState.instance == undefined) {

--- a/lib/build/recipeImplementation.js
+++ b/lib/build/recipeImplementation.js
@@ -1,34 +1,12 @@
-var __awaiter =
-    (this && this.__awaiter) ||
-    function(thisArg, _arguments, P, generator) {
-        function adopt(value) {
-            return value instanceof P
-                ? value
-                : new P(function(resolve) {
-                      resolve(value);
-                  });
-        }
-        return new (P || (P = Promise))(function(resolve, reject) {
-            function fulfilled(value) {
-                try {
-                    step(generator.next(value));
-                } catch (e) {
-                    reject(e);
-                }
-            }
-            function rejected(value) {
-                try {
-                    step(generator["throw"](value));
-                } catch (e) {
-                    reject(e);
-                }
-            }
-            function step(result) {
-                result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
-            }
-            step((generator = generator.apply(thisArg, _arguments || [])).next());
-        });
-    };
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
 import { URL } from "react-native-url-polyfill";
 import AuthHttpRequest, { onUnauthorisedResponse } from "./fetch";
 import FrontToken from "./frontToken";
@@ -39,21 +17,17 @@ import { getLocalSessionState, normaliseSessionScopeOrThrowError, normaliseURLDo
 import { logDebugMessage } from "./logger";
 export default function RecipeImplementation() {
     return {
-        addFetchInterceptorsAndReturnModifiedFetch: function(originalFetch, _) {
+        addFetchInterceptorsAndReturnModifiedFetch: function (originalFetch, _) {
             logDebugMessage("addFetchInterceptorsAndReturnModifiedFetch: called");
-            return function(url, config) {
-                return __awaiter(this, void 0, void 0, function*() {
-                    return yield AuthHttpRequest.doRequest(
-                        config => {
-                            return originalFetch(url, Object.assign({}, config));
-                        },
-                        config,
-                        url
-                    );
+            return function (url, config) {
+                return __awaiter(this, void 0, void 0, function* () {
+                    return yield AuthHttpRequest.doRequest((config) => {
+                        return originalFetch(url, Object.assign({}, config));
+                    }, config, url);
                 });
             };
         },
-        addAxiosInterceptors: function(axiosInstance, _) {
+        addAxiosInterceptors: function (axiosInstance, _) {
             logDebugMessage("addAxiosInterceptors: called");
             // we first check if this axiosInstance already has our interceptors.
             let requestInterceptors = axiosInstance.interceptors.request;
@@ -64,19 +38,16 @@ export default function RecipeImplementation() {
                 }
             }
             // Add a request interceptor
-            axiosInstance.interceptors.request.use(interceptorFunctionRequestFulfilled, function(error) {
-                return __awaiter(this, void 0, void 0, function*() {
+            axiosInstance.interceptors.request.use(interceptorFunctionRequestFulfilled, function (error) {
+                return __awaiter(this, void 0, void 0, function* () {
                     throw error;
                 });
             });
             // Add a response interceptor
-            axiosInstance.interceptors.response.use(
-                responseInterceptor(axiosInstance),
-                responseErrorInterceptor(axiosInstance)
-            );
+            axiosInstance.interceptors.response.use(responseInterceptor(axiosInstance), responseErrorInterceptor(axiosInstance));
         },
-        getUserId: function(config) {
-            return __awaiter(this, void 0, void 0, function*() {
+        getUserId: function (config) {
+            return __awaiter(this, void 0, void 0, function* () {
                 logDebugMessage("getUserId: called");
                 let tokenInfo = yield FrontToken.getTokenInfo();
                 if (tokenInfo === undefined) {
@@ -86,8 +57,8 @@ export default function RecipeImplementation() {
                 return tokenInfo.uid;
             });
         },
-        getAccessTokenPayloadSecurely: function(config) {
-            return __awaiter(this, void 0, void 0, function*() {
+        getAccessTokenPayloadSecurely: function (config) {
+            return __awaiter(this, void 0, void 0, function* () {
                 logDebugMessage("getAccessTokenPayloadSecurely: called");
                 let tokenInfo = yield FrontToken.getTokenInfo();
                 if (tokenInfo === undefined) {
@@ -98,7 +69,8 @@ export default function RecipeImplementation() {
                     let retry = yield AuthHttpRequest.attemptRefreshingSession();
                     if (retry) {
                         return yield this.getAccessTokenPayloadSecurely(config);
-                    } else {
+                    }
+                    else {
                         throw new Error("Could not refresh session");
                     }
                 }
@@ -106,8 +78,8 @@ export default function RecipeImplementation() {
                 return tokenInfo.up;
             });
         },
-        doesSessionExist: function(config) {
-            return __awaiter(this, void 0, void 0, function*() {
+        doesSessionExist: function (config) {
+            return __awaiter(this, void 0, void 0, function* () {
                 logDebugMessage("doesSessionExist: called");
                 const tokenInfo = yield FrontToken.getTokenInfo();
                 if (tokenInfo === undefined) {
@@ -123,8 +95,8 @@ export default function RecipeImplementation() {
                 return true;
             });
         },
-        signOut: function(config) {
-            return __awaiter(this, void 0, void 0, function*() {
+        signOut: function (config) {
+            return __awaiter(this, void 0, void 0, function* () {
                 logDebugMessage("signOut: called");
                 if (!(yield this.doesSessionExist(config))) {
                     config.onHandleEvent({
@@ -158,22 +130,19 @@ export default function RecipeImplementation() {
                 let responseJson = yield resp.clone().json();
                 if (responseJson.status === "GENERAL_ERROR") {
                     logDebugMessage("doRequest: Throwing general error");
-                    let message =
-                        responseJson.message === undefined ? "No Error Message Provided" : responseJson.message;
+                    let message = responseJson.message === undefined ? "No Error Message Provided" : responseJson.message;
                     throw new SuperTokensGeneralError(message);
                 }
                 // we do not send an event here since it's triggered in fireSessionUpdateEventsIfNecessary.
             });
         },
-        shouldDoInterceptionBasedOnUrl: function(toCheckUrl, apiDomain, sessionTokenBackendDomain) {
-            logDebugMessage(
-                "shouldDoInterceptionBasedOnUrl: toCheckUrl: " +
-                    toCheckUrl +
-                    " apiDomain: " +
-                    apiDomain +
-                    " sessionTokenBackendDomain: " +
-                    sessionTokenBackendDomain
-            );
+        shouldDoInterceptionBasedOnUrl: function (toCheckUrl, apiDomain, sessionTokenBackendDomain) {
+            logDebugMessage("shouldDoInterceptionBasedOnUrl: toCheckUrl: " +
+                toCheckUrl +
+                " apiDomain: " +
+                apiDomain +
+                " sessionTokenBackendDomain: " +
+                sessionTokenBackendDomain);
             // The safest/best way to add this is the hash as the browser strips it before sending
             // but we don't have a reason to limit checking to that part.
             if (toCheckUrl.includes("superTokensDoNotDoInterception")) {
@@ -193,7 +162,8 @@ export default function RecipeImplementation() {
                 // even if sessionTokenBackendDomain !== undefined, if there is an exact match
                 // of api domain, ignoring the port, we return true
                 return apiDomainAndInputDomainMatch;
-            } else {
+            }
+            else {
                 let normalisedsessionDomain = normaliseSessionScopeOrThrowError(sessionTokenBackendDomain);
                 return matchesDomainOrSubdomain(domain, normalisedsessionDomain);
             }

--- a/lib/build/types.js
+++ b/lib/build/types.js
@@ -12,3 +12,4 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
+export {};

--- a/lib/build/utils.js
+++ b/lib/build/utils.js
@@ -1,34 +1,12 @@
-var __awaiter =
-    (this && this.__awaiter) ||
-    function(thisArg, _arguments, P, generator) {
-        function adopt(value) {
-            return value instanceof P
-                ? value
-                : new P(function(resolve) {
-                      resolve(value);
-                  });
-        }
-        return new (P || (P = Promise))(function(resolve, reject) {
-            function fulfilled(value) {
-                try {
-                    step(generator.next(value));
-                } catch (e) {
-                    reject(e);
-                }
-            }
-            function rejected(value) {
-                try {
-                    step(generator["throw"](value));
-                } catch (e) {
-                    reject(e);
-                }
-            }
-            function step(result) {
-                result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
-            }
-            step((generator = generator.apply(thisArg, _arguments || [])).next());
-        });
-    };
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import { URL } from "react-native-url-polyfill";
 import AuthHttpRequest from "./fetch";
@@ -40,9 +18,7 @@ const LAST_ACCESS_TOKEN_UPDATE = "st-last-access-token-update";
 const REFRESH_TOKEN_NAME = "st-refresh-token";
 const ACCESS_TOKEN_NAME = "st-access-token";
 export function isAnIpAddress(ipaddress) {
-    return /^(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/.test(
-        ipaddress
-    );
+    return /^(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/.test(ipaddress);
 }
 export function normaliseURLDomainOrThrowError(input) {
     let str = new NormalisedURLDomain(input).getAsStringDangerous();
@@ -66,14 +42,13 @@ export function normaliseSessionScopeOrThrowError(cookieDomain) {
             let urlObj = new URL(cookieDomain);
             cookieDomain = urlObj.hostname;
             return cookieDomain;
-        } catch (err) {
+        }
+        catch (err) {
             throw new Error("Please provide a valid cookieDomain");
         }
     }
     function isAnIpAddress(ipaddress) {
-        return /^(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/.test(
-            ipaddress
-        );
+        return /^(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/.test(ipaddress);
     }
     let noDotNormalised = helper(cookieDomain);
     if (noDotNormalised === "localhost" || isAnIpAddress(noDotNormalised)) {
@@ -109,14 +84,13 @@ export function validateAndNormaliseInputOrThrowError(options) {
         }
         maxRetryAttemptsForSessionRefresh = options.maxRetryAttemptsForSessionRefresh;
     }
-    let preAPIHook = context =>
-        __awaiter(this, void 0, void 0, function*() {
-            return { url: context.url, requestInit: context.requestInit };
-        });
+    let preAPIHook = (context) => __awaiter(this, void 0, void 0, function* () {
+        return { url: context.url, requestInit: context.requestInit };
+    });
     if (options.preAPIHook !== undefined) {
         preAPIHook = options.preAPIHook;
     }
-    let onHandleEvent = () => {};
+    let onHandleEvent = () => { };
     if (options.onHandleEvent !== undefined) {
         onHandleEvent = options.onHandleEvent;
     }
@@ -142,7 +116,7 @@ export function setToken(tokenType, value) {
     return storeInStorage(name, value, Date.now() + 3153600000);
 }
 export function storeInStorage(name, value, expiry) {
-    return __awaiter(this, void 0, void 0, function*() {
+    return __awaiter(this, void 0, void 0, function* () {
         const storageKey = `st-storage-item-${name}`;
         if (value === "") {
             return yield AsyncStorage.removeItem(storageKey);
@@ -156,7 +130,7 @@ export function storeInStorage(name, value, expiry) {
  * to the refresh endpoint
  */
 export function saveLastAccessTokenUpdate() {
-    return __awaiter(this, void 0, void 0, function*() {
+    return __awaiter(this, void 0, void 0, function* () {
         logDebugMessage("saveLastAccessTokenUpdate: called");
         const now = Date.now().toString();
         logDebugMessage("saveLastAccessTokenUpdate: setting " + now);
@@ -175,7 +149,7 @@ export function getStorageNameForToken(tokenType) {
     }
 }
 function getFromStorage(name) {
-    return __awaiter(this, void 0, void 0, function*() {
+    return __awaiter(this, void 0, void 0, function* () {
         const itemInStorage = yield AsyncStorage.getItem(`st-storage-item-${name}`);
         if (itemInStorage === null) {
             return undefined;
@@ -184,7 +158,7 @@ function getFromStorage(name) {
     });
 }
 export function getTokenForHeaderAuth(tokenType) {
-    return __awaiter(this, void 0, void 0, function*() {
+    return __awaiter(this, void 0, void 0, function* () {
         const name = getStorageNameForToken(tokenType);
         return getFromStorage(name);
     });
@@ -195,19 +169,16 @@ export function getTokenForHeaderAuth(tokenType) {
  * but a session may still exist
  */
 export function getLocalSessionState() {
-    return __awaiter(this, void 0, void 0, function*() {
+    return __awaiter(this, void 0, void 0, function* () {
         logDebugMessage("getLocalSessionState: called");
         const lastAccessTokenUpdate = yield getFromStorage(LAST_ACCESS_TOKEN_UPDATE);
         const frontTokenExists = yield FrontToken.doesTokenExists();
         if (frontTokenExists && lastAccessTokenUpdate !== undefined) {
-            logDebugMessage(
-                "getLocalSessionState: returning EXISTS since both frontToken and lastAccessTokenUpdate exists"
-            );
+            logDebugMessage("getLocalSessionState: returning EXISTS since both frontToken and lastAccessTokenUpdate exists");
             return { status: "EXISTS", lastAccessTokenUpdate: lastAccessTokenUpdate };
-        } else {
-            logDebugMessage(
-                "getLocalSessionState: returning NOT_EXISTS since frontToken was cleared but lastAccessTokenUpdate exists"
-            );
+        }
+        else {
+            logDebugMessage("getLocalSessionState: returning NOT_EXISTS since frontToken was cleared but lastAccessTokenUpdate exists");
             return { status: "NOT_EXISTS" };
         }
     });
@@ -225,9 +196,7 @@ export function fireSessionUpdateEventsIfNecessary(wasLoggedIn, status, frontTok
     // if the current endpoint clears the session it'll set the front-token to remove
     // any other update means it's created or updated.
     const frontTokenExistsAfter = frontTokenHeaderFromResponse !== "remove";
-    logDebugMessage(
-        `fireSessionUpdateEventsIfNecessary wasLoggedIn: ${wasLoggedIn} frontTokenExistsAfter: ${frontTokenExistsAfter} status: ${status}`
-    );
+    logDebugMessage(`fireSessionUpdateEventsIfNecessary wasLoggedIn: ${wasLoggedIn} frontTokenExistsAfter: ${frontTokenExistsAfter} status: ${status}`);
     if (wasLoggedIn) {
         // we check for wasLoggedIn cause we don't want to fire an event
         // unnecessarily on first app load or if the user tried
@@ -239,14 +208,16 @@ export function fireSessionUpdateEventsIfNecessary(wasLoggedIn, status, frontTok
                     action: "UNAUTHORISED",
                     sessionExpiredOrRevoked: true
                 });
-            } else {
+            }
+            else {
                 logDebugMessage("onUnauthorisedResponse: firing SIGN_OUT event");
                 AuthHttpRequest.config.onHandleEvent({
                     action: "SIGN_OUT"
                 });
             }
         }
-    } else if (frontTokenExistsAfter) {
+    }
+    else if (frontTokenExistsAfter) {
         logDebugMessage("onUnauthorisedResponse: firing SESSION_CREATED event");
         AuthHttpRequest.config.onHandleEvent({
             action: "SESSION_CREATED"

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache 2.0",
       "dependencies": {
         "base-64": "^1.0.0",
-        "react-native-url-polyfill": "^1.3.0",
+        "react-native-url-polyfill": "^2.0.0",
         "supertokens-js-override": "^0.0.4"
       },
       "devDependencies": {
@@ -22,7 +22,7 @@
         "prettier": "1.18.2",
         "size-limit": "^6.0.4",
         "typedoc": "^0.22.5",
-        "typescript": "3.8.3"
+        "typescript": "4.4.3"
       },
       "peerDependencies": {
         "@react-native-async-storage/async-storage": ">=1.13.0 <2.0.x",
@@ -8651,7 +8651,9 @@
       }
     },
     "node_modules/react-native-url-polyfill": {
-      "version": "1.3.0",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/react-native-url-polyfill/-/react-native-url-polyfill-2.0.0.tgz",
+      "integrity": "sha512-My330Do7/DvKnEvwQc0WdcBnFPploYKp9CYlefDXzIdEaA+PAhDYllkvGeEroEzvc4Kzzj2O4yVdz8v6fjRvhA==",
       "license": "MIT",
       "dependencies": {
         "whatwg-url-without-unicode": "8.0.0-3"
@@ -10303,7 +10305,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "3.8.3",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.3.tgz",
+      "integrity": "sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -17258,7 +17262,9 @@
       }
     },
     "react-native-url-polyfill": {
-      "version": "1.3.0",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/react-native-url-polyfill/-/react-native-url-polyfill-2.0.0.tgz",
+      "integrity": "sha512-My330Do7/DvKnEvwQc0WdcBnFPploYKp9CYlefDXzIdEaA+PAhDYllkvGeEroEzvc4Kzzj2O4yVdz8v6fjRvhA==",
       "requires": {
         "whatwg-url-without-unicode": "8.0.0-3"
       }
@@ -18518,7 +18524,9 @@
       }
     },
     "typescript": {
-      "version": "3.8.3",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.3.tgz",
+      "integrity": "sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA==",
       "dev": true
     },
     "uglify-es": {

--- a/package.json
+++ b/package.json
@@ -44,12 +44,12 @@
     "axios": "*",
     "prettier": "1.18.2",
     "size-limit": "^6.0.4",
-    "typescript": "3.8.3",
+    "typescript": "4.4.3",
     "typedoc": "^0.22.5"
   },
   "dependencies": {
     "base-64": "^1.0.0",
-    "react-native-url-polyfill": "^1.3.0",
+    "react-native-url-polyfill": "^2.0.0",
     "supertokens-js-override": "^0.0.4"
   },
   "size-limit": [


### PR DESCRIPTION
## Summary of change
Punycode is marked as deprecated. I was trying an expo react native app and it and failed to start on android/ios emulators.
The patch to use `punycode.ucs2decode` instead of `punycode.ucs2.decode` worked on web but not on mobile.
The latest version of react-native-url-polyfill does not use punycode and resolves the issue.

## Related issues
- Link to issue1 here
- Link to issue1 here

## Test Plan
(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)
With expo I found it hard to test with local package. I did force my test app to use version 2.0.0 of react-native-url-polyfill and it successfully worked in emulator. If more testing is needed, I can help.

## Documentation changes
(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates
- [ ] Changelog has been updated
- [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
   - Along with the associated array in `lib/ts/version.ts`
- [ ] Changes to the version if needed
   - In `package.json`
   - In `package-lock.json`
   - In `lib/ts/version.ts`
- [ ] Had run `npm run build-pretty`
- [ ] Had installed and ran the pre-commit hook
- [ ] Issue this PR against the latest non released version branch.
   - To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
   - If no such branch exists, then create one from the latest released branch.

## Remaining TODOs for this PR
- [ ] Item1
- [ ] Item2