### PR TITLE
fix: Bump some versions and get rid of react-native-url-polyfill

### DIFF
--- a/lib/build/axios.d.ts
+++ b/lib/build/axios.d.ts
@@ -1,10 +1,10 @@
 import { AxiosPromise, AxiosRequestConfig as OriginalAxiosRequestConfig, AxiosResponse } from "axios";
-declare type AxiosRequestConfig = OriginalAxiosRequestConfig & {
+type AxiosRequestConfig = OriginalAxiosRequestConfig & {
     __supertokensSessionRefreshAttempts?: number;
     __supertokensAddedAuthHeader?: boolean;
 };
 export declare function interceptorFunctionRequestFulfilled(config: AxiosRequestConfig): Promise<AxiosRequestConfig>;
-export declare function responseInterceptor(axiosInstance: any): (response: AxiosResponse<any>) => Promise<AxiosResponse<any>>;
+export declare function responseInterceptor(axiosInstance: any): (response: AxiosResponse) => Promise<AxiosResponse<any>>;
 export declare function responseErrorInterceptor(axiosInstance: any): (error: any) => Promise<AxiosResponse<any>>;
 /**
  * @class AuthHttpRequest
@@ -17,6 +17,6 @@ export default class AuthHttpRequest {
      * attempts to call the refresh token API and if that is successful, calls this API again.
      * @throws Error
      */
-    static doRequest: (httpCall: (config: AxiosRequestConfig) => AxiosPromise<any>, config: AxiosRequestConfig, url?: string | undefined, prevResponse?: AxiosResponse<any> | undefined, prevError?: any, viaInterceptor?: boolean) => Promise<AxiosResponse<any>>;
+    static doRequest: (httpCall: (config: AxiosRequestConfig) => AxiosPromise<any>, config: AxiosRequestConfig, url?: string, prevResponse?: AxiosResponse, prevError?: any, viaInterceptor?: boolean) => Promise<AxiosResponse<any>>;
 }
 export {};

--- a/lib/build/axios.js
+++ b/lib/build/axios.js
@@ -29,6 +29,7 @@ var __awaiter =
             step((generator = generator.apply(thisArg, _arguments || [])).next());
         });
     };
+var _a;
 import { createAxiosErrorFromFetchResp } from "./axiosError";
 import AuthHttpRequestFetch, { onUnauthorisedResponse } from "./fetch";
 import FrontToken from "./frontToken";
@@ -226,15 +227,23 @@ export function responseErrorInterceptor(axiosInstance) {
  * @class AuthHttpRequest
  * @description wrapper for common http methods.
  */
-export default class AuthHttpRequest {}
+class AuthHttpRequest {}
+_a = AuthHttpRequest;
 /**
  * @description sends the actual http request and returns a response if successful/
  * If not successful due to session expiry reasons, it
  * attempts to call the refresh token API and if that is successful, calls this API again.
  * @throws Error
  */
-AuthHttpRequest.doRequest = (httpCall, config, url, prevResponse, prevError, viaInterceptor = false) =>
-    __awaiter(void 0, void 0, void 0, function*() {
+AuthHttpRequest.doRequest = (httpCall_1, config_1, url_1, prevResponse_1, prevError_1, ...args_1) =>
+    __awaiter(void 0, [httpCall_1, config_1, url_1, prevResponse_1, prevError_1, ...args_1], void 0, function*(
+        httpCall,
+        config,
+        url,
+        prevResponse,
+        prevError,
+        viaInterceptor = false
+    ) {
         if (!AuthHttpRequestFetch.initCalled) {
             throw Error("init function not called");
         }
@@ -384,6 +393,7 @@ AuthHttpRequest.doRequest = (httpCall, config, url, prevResponse, prevError, via
         // which means it's a 401, so we throw
         throw returnObj;
     });
+export default AuthHttpRequest;
 function saveTokensFromHeaders(response) {
     return __awaiter(this, void 0, void 0, function*() {
         logDebugMessage("saveTokensFromHeaders: Saving updated tokens from the response");

--- a/lib/build/fetch.d.ts
+++ b/lib/build/fetch.d.ts
@@ -19,7 +19,7 @@ export default class AuthHttpRequest {
      * attempts to call the refresh token API and if that is successful, calls this API again.
      * @throws Error
      */
-    static doRequest: (httpCall: (config?: RequestInit | undefined) => Promise<Response>, config?: RequestInit | undefined, url?: any) => Promise<Response>;
+    static doRequest: (httpCall: (config?: RequestInit) => Promise<Response>, config?: RequestInit, url?: any) => Promise<Response>;
     static attemptRefreshingSession: () => Promise<boolean>;
 }
 export declare function onUnauthorisedResponse(preRequestLocalSessionState: LocalSessionState): Promise<{

--- a/lib/build/fetch.js
+++ b/lib/build/fetch.js
@@ -43,6 +43,7 @@ var __awaiter =
             step((generator = generator.apply(thisArg, _arguments || [])).next());
         });
     };
+var _a;
 import { PROCESS_STATE, ProcessState } from "./processState";
 import { supported_fdi } from "./version";
 import AntiCSRF from "./antiCsrf";
@@ -62,7 +63,7 @@ import { logDebugMessage, enableLogging } from "./logger";
  * @class AuthHttpRequest
  * @description wrapper for common http methods.
  */
-export default class AuthHttpRequest {
+class AuthHttpRequest {
     static init(options) {
         let config = validateAndNormaliseInputOrThrowError(options);
         if (options.enableDebugLogs !== undefined && options.enableDebugLogs) {
@@ -75,33 +76,32 @@ export default class AuthHttpRequest {
         logDebugMessage("init: Input sessionTokenBackendDomain: " + config.sessionTokenBackendDomain);
         logDebugMessage("init: Input sessionExpiredStatusCode: " + config.sessionExpiredStatusCode);
         logDebugMessage("init: Input tokenTransferMethod: " + config.tokenTransferMethod);
-        AuthHttpRequest.env = global;
-        AuthHttpRequest.refreshTokenUrl = config.apiDomain + config.apiBasePath + "/session/refresh";
-        AuthHttpRequest.signOutUrl = config.apiDomain + config.apiBasePath + "/signout";
-        AuthHttpRequest.rid = "session";
-        AuthHttpRequest.config = config;
-        if (AuthHttpRequest.env.__supertokensOriginalFetch === undefined) {
+        _a.env = global;
+        _a.refreshTokenUrl = config.apiDomain + config.apiBasePath + "/session/refresh";
+        _a.signOutUrl = config.apiDomain + config.apiBasePath + "/signout";
+        _a.rid = "session";
+        _a.config = config;
+        if (_a.env.__supertokensOriginalFetch === undefined) {
             logDebugMessage("init: __supertokensOriginalFetch is undefined");
             // this block contains code that is run just once per page load..
             // all items in this block are attached to the global env so that
             // even if the init function is called more than once (maybe across JS scripts),
             // things will not get created multiple times.
-            AuthHttpRequest.env.__supertokensOriginalFetch = AuthHttpRequest.env.fetch.bind(AuthHttpRequest.env);
+            _a.env.__supertokensOriginalFetch = _a.env.fetch.bind(_a.env);
             {
                 const builder = new OverrideableBuilder(RecipeImplementation());
-                AuthHttpRequest.env.__supertokensSessionRecipe = builder
-                    .override(this.config.override.functions)
-                    .build();
+                _a.env.__supertokensSessionRecipe = builder.override(this.config.override.functions).build();
             }
-            AuthHttpRequest.env.fetch = AuthHttpRequest.env.__supertokensSessionRecipe.addFetchInterceptorsAndReturnModifiedFetch(
-                AuthHttpRequest.env.__supertokensOriginalFetch,
+            _a.env.fetch = _a.env.__supertokensSessionRecipe.addFetchInterceptorsAndReturnModifiedFetch(
+                _a.env.__supertokensOriginalFetch,
                 config
             );
         }
-        AuthHttpRequest.recipeImpl = AuthHttpRequest.env.__supertokensSessionRecipe;
-        AuthHttpRequest.initCalled = true;
+        _a.recipeImpl = _a.env.__supertokensSessionRecipe;
+        _a.initCalled = true;
     }
 }
+_a = AuthHttpRequest;
 AuthHttpRequest.initCalled = false;
 /**
  * @description sends the actual http request and returns a response if successful/
@@ -111,7 +111,7 @@ AuthHttpRequest.initCalled = false;
  */
 AuthHttpRequest.doRequest = (httpCall, config, url) =>
     __awaiter(void 0, void 0, void 0, function*() {
-        if (!AuthHttpRequest.initCalled) {
+        if (!_a.initCalled) {
             throw Error("init function not called");
         }
         logDebugMessage("doRequest: start of fetch interception");
@@ -119,17 +119,17 @@ AuthHttpRequest.doRequest = (httpCall, config, url) =>
         try {
             doNotDoInterception =
                 (typeof url === "string" &&
-                    !AuthHttpRequest.recipeImpl.shouldDoInterceptionBasedOnUrl(
+                    !_a.recipeImpl.shouldDoInterceptionBasedOnUrl(
                         url,
-                        AuthHttpRequest.config.apiDomain,
-                        AuthHttpRequest.config.sessionTokenBackendDomain
+                        _a.config.apiDomain,
+                        _a.config.sessionTokenBackendDomain
                     )) ||
                 (url !== undefined &&
                 typeof url.url === "string" && // this is because url can be an object like {method: ..., url: ...}
-                    !AuthHttpRequest.recipeImpl.shouldDoInterceptionBasedOnUrl(
+                    !_a.recipeImpl.shouldDoInterceptionBasedOnUrl(
                         url.url,
-                        AuthHttpRequest.config.apiDomain,
-                        AuthHttpRequest.config.sessionTokenBackendDomain
+                        _a.config.apiDomain,
+                        _a.config.sessionTokenBackendDomain
                     ));
         } catch (err) {
             // This is because in react native it is not possible to call fetch with only a path (Example fetch("/login"))
@@ -178,7 +178,7 @@ AuthHttpRequest.doRequest = (httpCall, config, url) =>
                     clonedHeaders.set("anti-csrf", antiCsrfToken);
                 }
             }
-            if (AuthHttpRequest.config.autoAddCredentials) {
+            if (_a.config.autoAddCredentials) {
                 logDebugMessage("doRequest: Adding credentials include");
                 if (configWithAntiCsrf === undefined) {
                     configWithAntiCsrf = {
@@ -197,7 +197,7 @@ AuthHttpRequest.doRequest = (httpCall, config, url) =>
             } else {
                 logDebugMessage("doRequest: rid header was already there in request");
             }
-            const transferMethod = AuthHttpRequest.config.tokenTransferMethod;
+            const transferMethod = _a.config.tokenTransferMethod;
             logDebugMessage("doRequest: Adding st-auth-mode header: " + transferMethod);
             clonedHeaders.set("st-auth-mode", transferMethod);
             yield setAuthorizationHeaderIfRequired(clonedHeaders);
@@ -210,19 +210,19 @@ AuthHttpRequest.doRequest = (httpCall, config, url) =>
                 response.status,
                 response.headers.get("front-token")
             );
-            if (response.status === AuthHttpRequest.config.sessionExpiredStatusCode) {
+            if (response.status === _a.config.sessionExpiredStatusCode) {
                 logDebugMessage("doRequest: Status code is: " + response.status);
                 /**
                  * An API may return a 401 error response even with a valid session, causing a session refresh loop in the interceptor.
                  * To prevent this infinite loop, we break out of the loop after retrying the original request a specified number of times.
                  * The maximum number of retry attempts is defined by maxRetryAttemptsForSessionRefresh config variable.
                  */
-                if (sessionRefreshAttempts >= AuthHttpRequest.config.maxRetryAttemptsForSessionRefresh) {
+                if (sessionRefreshAttempts >= _a.config.maxRetryAttemptsForSessionRefresh) {
                     logDebugMessage(
-                        `doRequest: Maximum session refresh attempts reached. sessionRefreshAttempts: ${sessionRefreshAttempts}, maxRetryAttemptsForSessionRefresh: ${AuthHttpRequest.config.maxRetryAttemptsForSessionRefresh}`
+                        `doRequest: Maximum session refresh attempts reached. sessionRefreshAttempts: ${sessionRefreshAttempts}, maxRetryAttemptsForSessionRefresh: ${_a.config.maxRetryAttemptsForSessionRefresh}`
                     );
                     throw new Error(
-                        `Received a 401 response from ${url}. Attempted to refresh the session and retry the request with the updated session tokens ${AuthHttpRequest.config.maxRetryAttemptsForSessionRefresh} times, but each attempt resulted in a 401 error. The maximum session refresh limit has been reached. Please investigate your API. To increase the session refresh attempts, update maxRetryAttemptsForSessionRefresh in the config.`
+                        `Received a 401 response from ${url}. Attempted to refresh the session and retry the request with the updated session tokens ${_a.config.maxRetryAttemptsForSessionRefresh} times, but each attempt resulted in a 401 error. The maximum session refresh limit has been reached. Please investigate your API. To increase the session refresh attempts, update maxRetryAttemptsForSessionRefresh in the config.`
                     );
                 }
                 let refreshResponse = yield onUnauthorisedResponse(preRequestLocalSessionState);
@@ -242,7 +242,7 @@ AuthHttpRequest.doRequest = (httpCall, config, url) =>
     });
 AuthHttpRequest.attemptRefreshingSession = () =>
     __awaiter(void 0, void 0, void 0, function*() {
-        if (!AuthHttpRequest.initCalled) {
+        if (!_a.initCalled) {
             throw new Error("init function not called");
         }
         const preRequestLocalSessionState = yield getLocalSessionState();
@@ -252,6 +252,7 @@ AuthHttpRequest.attemptRefreshingSession = () =>
         }
         return refreshResponse.result === "RETRY";
     });
+export default AuthHttpRequest;
 const LOCK_NAME = "REFRESH_TOKEN_USE";
 export function onUnauthorisedResponse(preRequestLocalSessionState) {
     return __awaiter(this, void 0, void 0, function*() {
@@ -394,8 +395,8 @@ function saveTokensFromHeaders(response) {
         }
     });
 }
-function setAuthorizationHeaderIfRequired(clonedHeaders, addRefreshToken = false) {
-    return __awaiter(this, void 0, void 0, function*() {
+function setAuthorizationHeaderIfRequired(clonedHeaders_1) {
+    return __awaiter(this, arguments, void 0, function*(clonedHeaders, addRefreshToken = false) {
         logDebugMessage("setTokenHeaders: adding existing tokens as header");
         // We set the Authorization header even if the tokenTransferMethod preference set in the config is cookies
         // since the active session may be using cookies. By default, we want to allow users to continue these sessions.

--- a/lib/build/frontToken.js
+++ b/lib/build/frontToken.js
@@ -36,7 +36,7 @@ import { logDebugMessage } from "./logger";
 import AntiCSRF from "./antiCsrf";
 const FRONT_TOKEN_KEY = "supertokens-rn-front-token-key";
 const FRONT_TOKEN_NAME = "sFrontToken";
-export default class FrontToken {
+class FrontToken {
     constructor() {}
     static getFrontTokenFromStorage() {
         return __awaiter(this, void 0, void 0, function*() {
@@ -160,3 +160,4 @@ export default class FrontToken {
 // these are waiters for when the idRefreshToken has been set, but this token has
 // not yet been set. Once this token is set or removed, the waiters are resolved.
 FrontToken.waiters = [];
+export default FrontToken;

--- a/lib/build/index.js
+++ b/lib/build/index.js
@@ -43,15 +43,16 @@ var __awaiter =
             step((generator = generator.apply(thisArg, _arguments || [])).next());
         });
     };
+var _a;
 import AuthHttpRequestFetch from "./fetch";
 import { getTokenForHeaderAuth } from "./utils";
-export default class AuthHttpRequest {
+class AuthHttpRequest {
     static init(options) {
         AuthHttpRequestFetch.init(options);
-        AuthHttpRequest.axiosInterceptorQueue.forEach(f => {
+        _a.axiosInterceptorQueue.forEach(f => {
             f();
         });
-        AuthHttpRequest.axiosInterceptorQueue = [];
+        _a.axiosInterceptorQueue = [];
     }
     static getUserId() {
         if (!AuthHttpRequestFetch.initCalled) {
@@ -68,6 +69,7 @@ export default class AuthHttpRequest {
         });
     }
 }
+_a = AuthHttpRequest;
 AuthHttpRequest.axiosInterceptorQueue = [];
 AuthHttpRequest.attemptRefreshingSession = () =>
     __awaiter(void 0, void 0, void 0, function*() {
@@ -84,7 +86,7 @@ AuthHttpRequest.addAxiosInterceptors = axiosInstance => {
         // the recipe implementation has not been initialised yet, so add
         // this to the queue and wait for it to be initialised, and then on
         // init call, we add all the interceptors.
-        AuthHttpRequest.axiosInterceptorQueue.push(() => {
+        _a.axiosInterceptorQueue.push(() => {
             AuthHttpRequestFetch.recipeImpl.addAxiosInterceptors(axiosInstance, AuthHttpRequestFetch.config);
         });
     } else {
@@ -108,6 +110,7 @@ AuthHttpRequest.getAccessToken = () =>
         }
         return undefined;
     });
+export default AuthHttpRequest;
 export let init = AuthHttpRequest.init;
 export let getUserId = AuthHttpRequest.getUserId;
 export let getAccessTokenPayloadSecurely = AuthHttpRequest.getAccessTokenPayloadSecurely;

--- a/lib/build/normalisedURLDomain.js
+++ b/lib/build/normalisedURLDomain.js
@@ -12,8 +12,8 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
+import { logDebugMessage } from "./logger";
 import { isAnIpAddress } from "./utils";
-import { URL } from "react-native-url-polyfill";
 export default class NormalisedURLDomain {
     constructor(url) {
         this.getAsStringDangerous = () => {
@@ -24,11 +24,11 @@ export default class NormalisedURLDomain {
 }
 function normaliseURLDomainOrThrowError(input, ignoreProtocol = false) {
     input = input.trim();
+    let error = null;
     try {
         if (!input.startsWith("http://") && !input.startsWith("https://")) {
             throw new Error("converting to proper URL");
         }
-        // @ts-ignore (Typescript complains that URL does not expect a parameter in constructor even though it does for react-native-url-polyfill)
         const urlObj = new URL(input);
         if (ignoreProtocol) {
             if (urlObj.hostname.startsWith("localhost") || isAnIpAddress(urlObj.hostname)) {
@@ -41,7 +41,10 @@ function normaliseURLDomainOrThrowError(input, ignoreProtocol = false) {
         }
         return input;
         // eslint-disable-next-line no-empty
-    } catch (err) {}
+    } catch (err) {
+        error = err;
+        logDebugMessage(err);
+    }
     if (input.startsWith("/")) {
         throw new Error("Please provide a valid domain name");
     }
@@ -59,11 +62,15 @@ function normaliseURLDomainOrThrowError(input, ignoreProtocol = false) {
         input = "https://" + input;
         // at this point, it should be a valid URL. So we test that before doing a recursive call
         try {
-            // @ts-ignore (Typescript complains that URL does not expect a parameter in constructor even though it does for react-native-url-polyfill)
             new URL(input);
             return normaliseURLDomainOrThrowError(input, true);
             // eslint-disable-next-line no-empty
-        } catch (err) {}
+        } catch (err) {
+            throw err;
+        }
     }
-    throw new Error("Please provide a valid domain name");
+    if (error === null) {
+        error = new Error("Please provide a valid domain name");
+    }
+    throw error;
 }

--- a/lib/build/normalisedURLPath.js
+++ b/lib/build/normalisedURLPath.js
@@ -12,7 +12,6 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-import { URL } from "react-native-url-polyfill";
 export default class NormalisedURLPath {
     constructor(url) {
         this.startsWith = other => {
@@ -33,7 +32,6 @@ function normaliseURLPathOrThrowError(input) {
         if (!input.startsWith("http://") && !input.startsWith("https://")) {
             throw new Error("converting to proper URL");
         }
-        // @ts-ignore (Typescript complains that URL does not expect a parameter in constructor even though it does for react-native-url-polyfill)
         const urlObj = new URL(input);
         input = urlObj.pathname;
         if (input.charAt(input.length - 1) === "/") {
@@ -59,7 +57,6 @@ function normaliseURLPathOrThrowError(input) {
     // at this point, we should be able to convert it into a fake URL and recursively call this function.
     try {
         // test that we can convert this to prevent an infinite loop
-        // @ts-ignore (Typescript complains that URL does not expect a parameter in constructor even though it does for react-native-url-polyfill)
         new URL("http://example.com" + input);
         return normaliseURLPathOrThrowError("http://example.com" + input);
     } catch (err) {
@@ -72,12 +69,10 @@ function domainGiven(input) {
         return false;
     }
     try {
-        // @ts-ignore (Typescript complains that URL does not expect a parameter in constructor even though it does for react-native-url-polyfill)
         const url = new URL(input);
         return url.hostname.indexOf(".") !== -1;
     } catch (e) {}
     try {
-        // @ts-ignore (Typescript complains that URL does not expect a parameter in constructor even though it does for react-native-url-polyfill)
         const url = new URL("http://" + input);
         return url.hostname.indexOf(".") !== -1;
     } catch (e) {}

--- a/lib/build/processState.js
+++ b/lib/build/processState.js
@@ -69,8 +69,8 @@ export class ProcessState {
         this.reset = () => {
             this.history = [];
         };
-        this.waitForEvent = (state, timeInMS = 7000) =>
-            __awaiter(this, void 0, void 0, function*() {
+        this.waitForEvent = (state_1, ...args_1) =>
+            __awaiter(this, [state_1, ...args_1], void 0, function*(state, timeInMS = 7000) {
                 let startTime = Date.now();
                 return new Promise(resolve => {
                     let actualThis = this;

--- a/lib/build/recipeImplementation.js
+++ b/lib/build/recipeImplementation.js
@@ -29,7 +29,6 @@ var __awaiter =
             step((generator = generator.apply(thisArg, _arguments || [])).next());
         });
     };
-import { URL } from "react-native-url-polyfill";
 import AuthHttpRequest, { onUnauthorisedResponse } from "./fetch";
 import FrontToken from "./frontToken";
 import { supported_fdi } from "./version";

--- a/lib/build/types.d.ts
+++ b/lib/build/types.d.ts
@@ -1,12 +1,12 @@
 import OverrideableBuilder from "supertokens-js-override";
-export declare type Event = {
+export type Event = {
     action: "SIGN_OUT" | "REFRESH_SESSION" | "SESSION_CREATED";
 } | {
     action: "UNAUTHORISED";
     sessionExpiredOrRevoked: boolean;
 };
-export declare type EventHandler = (event: Event) => void;
-export declare type InputType = {
+export type EventHandler = (event: Event) => void;
+export type InputType = {
     enableDebugLogs?: boolean;
     apiDomain: string;
     apiBasePath?: string;
@@ -34,7 +34,7 @@ export declare type InputType = {
         functions?: (originalImplementation: RecipeInterface, builder?: OverrideableBuilder<RecipeInterface>) => RecipeInterface;
     };
 };
-export declare type NormalisedInputType = {
+export type NormalisedInputType = {
     apiDomain: string;
     apiBasePath: string;
     sessionExpiredStatusCode: number;
@@ -55,14 +55,14 @@ export declare type NormalisedInputType = {
         functions: (originalImplementation: RecipeInterface, builder?: OverrideableBuilder<RecipeInterface>) => RecipeInterface;
     };
 };
-export declare type PreAPIHookFunction = (context: {
+export type PreAPIHookFunction = (context: {
     requestInit: RequestInit;
     url: string;
 }) => Promise<{
     url: string;
     requestInit: RequestInit;
 }>;
-export declare type RecipeInterface = {
+export type RecipeInterface = {
     addFetchInterceptorsAndReturnModifiedFetch: (originalFetch: any, config: NormalisedInputType) => typeof fetch;
     addAxiosInterceptors: (axiosInstance: any, config: NormalisedInputType) => void;
     getUserId: (config: NormalisedInputType) => Promise<string>;
@@ -71,10 +71,10 @@ export declare type RecipeInterface = {
     signOut: (config: NormalisedInputType) => Promise<void>;
     shouldDoInterceptionBasedOnUrl(toCheckUrl: string, apiDomain: string, sessionTokenBackendDomain: string | undefined): boolean;
 };
-export declare type IdRefreshTokenType = {
+export type IdRefreshTokenType = {
     status: "NOT_EXISTS" | "MAY_EXIST";
 } | {
     status: "EXISTS";
     token: string;
 };
-export declare type TokenType = "access" | "refresh";
+export type TokenType = "access" | "refresh";

--- a/lib/build/types.js
+++ b/lib/build/types.js
@@ -12,3 +12,4 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
+export {};

--- a/lib/build/utils.d.ts
+++ b/lib/build/utils.d.ts
@@ -14,7 +14,7 @@ export declare function storeInStorage(name: string, value: string, expiry: numb
 export declare function saveLastAccessTokenUpdate(): Promise<void>;
 export declare function getStorageNameForToken(tokenType: TokenType): "st-access-token" | "st-refresh-token";
 export declare function getTokenForHeaderAuth(tokenType: TokenType): Promise<string | undefined>;
-export declare type LocalSessionState = {
+export type LocalSessionState = {
     status: "NOT_EXISTS" | "MAY_EXIST";
 } | {
     status: "EXISTS";

--- a/lib/build/utils.js
+++ b/lib/build/utils.js
@@ -30,7 +30,6 @@ var __awaiter =
         });
     };
 import AsyncStorage from "@react-native-async-storage/async-storage";
-import { URL } from "react-native-url-polyfill";
 import AuthHttpRequest from "./fetch";
 import FrontToken from "./frontToken";
 import NormalisedURLDomain from "./normalisedURLDomain";
@@ -62,7 +61,6 @@ export function normaliseSessionScopeOrThrowError(cookieDomain) {
             cookieDomain = "http://" + cookieDomain;
         }
         try {
-            // @ts-ignore (Typescript complains that URL does not expect a parameter in constructor even though it does for react-native-url-polyfill)
             let urlObj = new URL(cookieDomain);
             cookieDomain = urlObj.hostname;
             return cookieDomain;

--- a/lib/ts/normalisedURLPath.ts
+++ b/lib/ts/normalisedURLPath.ts
@@ -12,7 +12,6 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-import { URL } from "react-native-url-polyfill";
 
 export default class NormalisedURLPath {
     private value: string;
@@ -40,8 +39,7 @@ function normaliseURLPathOrThrowError(input: string): string {
         if (!input.startsWith("http://") && !input.startsWith("https://")) {
             throw new Error("converting to proper URL");
         }
-        // @ts-ignore (Typescript complains that URL does not expect a parameter in constructor even though it does for react-native-url-polyfill)
-        const urlObj: any = new URL(input);
+        const urlObj = new URL(input);
         input = urlObj.pathname;
 
         if (input.charAt(input.length - 1) === "/") {
@@ -70,7 +68,6 @@ function normaliseURLPathOrThrowError(input: string): string {
     // at this point, we should be able to convert it into a fake URL and recursively call this function.
     try {
         // test that we can convert this to prevent an infinite loop
-        // @ts-ignore (Typescript complains that URL does not expect a parameter in constructor even though it does for react-native-url-polyfill)
         new URL("http://example.com" + input);
         return normaliseURLPathOrThrowError("http://example.com" + input);
     } catch (err) {
@@ -85,14 +82,12 @@ function domainGiven(input: string): boolean {
     }
 
     try {
-        // @ts-ignore (Typescript complains that URL does not expect a parameter in constructor even though it does for react-native-url-polyfill)
-        const url: any = new URL(input);
+        const url = new URL(input);
         return url.hostname.indexOf(".") !== -1;
     } catch (e) {}
 
     try {
-        // @ts-ignore (Typescript complains that URL does not expect a parameter in constructor even though it does for react-native-url-polyfill)
-        const url: any = new URL("http://" + input);
+        const url = new URL("http://" + input);
         return url.hostname.indexOf(".") !== -1;
     } catch (e) {}
 

--- a/lib/ts/recipeImplementation.ts
+++ b/lib/ts/recipeImplementation.ts
@@ -1,4 +1,3 @@
-import { URL } from "react-native-url-polyfill";
 import { RecipeInterface, NormalisedInputType } from "./types";
 import AuthHttpRequest, { onUnauthorisedResponse } from "./fetch";
 import FrontToken from "./frontToken";

--- a/lib/ts/utils.ts
+++ b/lib/ts/utils.ts
@@ -1,5 +1,4 @@
 import AsyncStorage from "@react-native-async-storage/async-storage";
-import { URL } from "react-native-url-polyfill";
 import AuthHttpRequest from "./fetch";
 import FrontToken from "./frontToken";
 import NormalisedURLDomain from "./normalisedURLDomain";
@@ -40,8 +39,7 @@ export function normaliseSessionScopeOrThrowError(cookieDomain: string): string 
         }
 
         try {
-            // @ts-ignore (Typescript complains that URL does not expect a parameter in constructor even though it does for react-native-url-polyfill)
-            let urlObj: any = new URL(cookieDomain);
+            let urlObj = new URL(cookieDomain);
             cookieDomain = urlObj.hostname;
 
             return cookieDomain;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,15 @@
 {
   "name": "supertokens-react-native",
-  "version": "5.1.4",
+  "version": "5.1.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "supertokens-react-native",
-      "version": "5.1.4",
+      "version": "5.1.5",
       "license": "Apache 2.0",
       "dependencies": {
         "base-64": "^1.0.0",
-        "react-native-url-polyfill": "^1.3.0",
         "supertokens-js-override": "^0.0.4"
       },
       "devDependencies": {
@@ -21,8 +20,8 @@
         "axios": "*",
         "prettier": "1.18.2",
         "size-limit": "^6.0.4",
-        "typedoc": "^0.22.5",
-        "typescript": "3.8.3"
+        "typedoc": "0.28.5",
+        "typescript": "5.8.3"
       },
       "peerDependencies": {
         "@react-native-async-storage/async-storage": ">=1.13.0 <2.0.x",
@@ -2085,6 +2084,20 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/@gerrit0/mini-shiki": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@gerrit0/mini-shiki/-/mini-shiki-3.6.0.tgz",
+      "integrity": "sha512-KaeJvPNofTEZR9EzVNp/GQzbQqkGfjiu6k3CXKvhVTX+8OoAKSX/k7qxLKOX3B0yh2XqVAc93rsOu48CGt2Qug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/engine-oniguruma": "^3.6.0",
+        "@shikijs/langs": "^3.6.0",
+        "@shikijs/themes": "^3.6.0",
+        "@shikijs/types": "^3.6.0",
+        "@shikijs/vscode-textmate": "^10.0.2"
+      }
+    },
     "node_modules/@hapi/hoek": {
       "version": "9.3.0",
       "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
@@ -2449,6 +2462,55 @@
       "integrity": "sha512-K0aGNn1TjalKj+65D7ycc1//H9roAQ51GJVk5ZJQFb2teECGmzd86bYDC0aYdbRf7gtovescq4Zt6FR0tgXiHQ==",
       "peer": true
     },
+    "node_modules/@shikijs/engine-oniguruma": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.6.0.tgz",
+      "integrity": "sha512-nmOhIZ9yT3Grd+2plmW/d8+vZ2pcQmo/UnVwXMUXAKTXdi+LK0S08Ancrz5tQQPkxvjBalpMW2aKvwXfelauvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.6.0",
+        "@shikijs/vscode-textmate": "^10.0.2"
+      }
+    },
+    "node_modules/@shikijs/langs": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.6.0.tgz",
+      "integrity": "sha512-IdZkQJaLBu1LCYCwkr30hNuSDfllOT8RWYVZK1tD2J03DkiagYKRxj/pDSl8Didml3xxuyzUjgtioInwEQM/TA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.6.0"
+      }
+    },
+    "node_modules/@shikijs/themes": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.6.0.tgz",
+      "integrity": "sha512-Fq2j4nWr1DF4drvmhqKq8x5vVQ27VncF8XZMBuHuQMZvUSS3NBgpqfwz/FoGe36+W6PvniZ1yDlg2d4kmYDU6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.6.0"
+      }
+    },
+    "node_modules/@shikijs/types": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.6.0.tgz",
+      "integrity": "sha512-cLWFiToxYu0aAzJqhXTQsFiJRTFDAGl93IrMSBNaGSzs7ixkLfdG6pH11HipuWFGW5vyx4X47W8HDQ7eSrmBUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      }
+    },
+    "node_modules/@shikijs/vscode-textmate": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
+      "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@sideway/address": {
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.4.tgz",
@@ -2745,6 +2807,16 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/hast": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.4.tgz",
@@ -2816,6 +2888,13 @@
     },
     "node_modules/@types/semver": {
       "version": "7.3.9",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -3433,7 +3512,8 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/big-integer": {
       "version": "1.6.51",
@@ -3481,6 +3561,7 @@
     "node_modules/brace-expansion": {
       "version": "1.1.11",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -3530,28 +3611,6 @@
       "peer": true,
       "dependencies": {
         "node-int64": "^0.4.0"
-      }
-    },
-    "node_modules/buffer": {
-      "version": "5.7.1",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.1.13"
       }
     },
     "node_modules/buffer-from": {
@@ -4045,7 +4104,8 @@
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/connect": {
       "version": "3.7.0",
@@ -5161,7 +5221,8 @@
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/fsevents": {
       "version": "2.3.2",
@@ -5236,6 +5297,7 @@
     "node_modules/glob": {
       "version": "7.2.0",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -5493,24 +5555,6 @@
         "postcss": "^8.1.0"
       }
     },
-    "node_modules/ieee754": {
-      "version": "1.2.1",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "BSD-3-Clause"
-    },
     "node_modules/ignore": {
       "version": "5.1.8",
       "dev": true,
@@ -5556,6 +5600,7 @@
     "node_modules/inflight": {
       "version": "1.0.6",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -5563,7 +5608,8 @@
     },
     "node_modules/inherits": {
       "version": "2.0.4",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/invariant": {
       "version": "2.2.4",
@@ -6275,11 +6321,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/jsonc-parser": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/jsonfile": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
@@ -6340,6 +6381,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^2.0.0"
       }
     },
     "node_modules/loader-runner": {
@@ -6499,14 +6550,6 @@
         "loose-envify": "cli.js"
       }
     },
-    "node_modules/lru-cache": {
-      "version": "5.1.1",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^3.0.2"
-      }
-    },
     "node_modules/lunr": {
       "version": "2.3.9",
       "dev": true,
@@ -6564,15 +6607,42 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/marked": {
-      "version": "3.0.7",
+    "node_modules/markdown-it": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.0.tgz",
+      "integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
       "dev": true,
       "license": "MIT",
-      "bin": {
-        "marked": "bin/marked"
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "^4.4.0",
+        "linkify-it": "^5.0.0",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
       },
+      "bin": {
+        "markdown-it": "bin/markdown-it.mjs"
+      }
+    },
+    "node_modules/markdown-it/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/markdown-it/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
       "engines": {
-        "node": ">= 12"
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/md5": {
@@ -6589,6 +6659,13 @@
       "version": "2.0.14",
       "dev": true,
       "license": "CC0-1.0"
+    },
+    "node_modules/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/merge-options": {
       "version": "3.0.4",
@@ -7122,6 +7199,7 @@
     "node_modules/minimatch": {
       "version": "3.0.4",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -7512,6 +7590,7 @@
     "node_modules/once": {
       "version": "1.4.0",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "wrappy": "1"
       }
@@ -7526,14 +7605,6 @@
       },
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/onigasm": {
-      "version": "2.2.5",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "lru-cache": "^5.1.1"
       }
     },
     "node_modules/open": {
@@ -7760,6 +7831,7 @@
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8500,6 +8572,17 @@
     },
     "node_modules/punycode": {
       "version": "2.1.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -8648,16 +8731,6 @@
         "flow-parser": "^0.121.0",
         "jscodeshift": "^0.11.0",
         "nullthrows": "^1.1.1"
-      }
-    },
-    "node_modules/react-native-url-polyfill": {
-      "version": "1.3.0",
-      "license": "MIT",
-      "dependencies": {
-        "whatwg-url-without-unicode": "8.0.0-3"
-      },
-      "peerDependencies": {
-        "react-native": "*"
       }
     },
     "node_modules/react-refresh": {
@@ -9420,16 +9493,6 @@
         "array-map": "~0.0.0",
         "array-reduce": "~0.0.0",
         "jsonify": "~0.0.0"
-      }
-    },
-    "node_modules/shiki": {
-      "version": "0.9.12",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "jsonc-parser": "^3.0.0",
-        "onigasm": "^2.2.5",
-        "vscode-textmate": "5.2.0"
       }
     },
     "node_modules/signal-exit": {
@@ -10282,28 +10345,72 @@
       }
     },
     "node_modules/typedoc": {
-      "version": "0.22.6",
+      "version": "0.28.5",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.28.5.tgz",
+      "integrity": "sha512-5PzUddaA9FbaarUzIsEc4wNXCiO4Ot3bJNeMF2qKpYlTmM9TTaSHQ7162w756ERCkXER/+o2purRG6YOAv6EMA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "glob": "^7.2.0",
+        "@gerrit0/mini-shiki": "^3.2.2",
         "lunr": "^2.3.9",
-        "marked": "^3.0.4",
-        "minimatch": "^3.0.4",
-        "shiki": "^0.9.11"
+        "markdown-it": "^14.1.0",
+        "minimatch": "^9.0.5",
+        "yaml": "^2.7.1"
       },
       "bin": {
         "typedoc": "bin/typedoc"
       },
       "engines": {
-        "node": ">= 12.10.0"
+        "node": ">= 18",
+        "pnpm": ">= 10"
       },
       "peerDependencies": {
-        "typescript": "4.0.x || 4.1.x || 4.2.x || 4.3.x || 4.4.x"
+        "typescript": "5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x || 5.8.x"
+      }
+    },
+    "node_modules/typedoc/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/typedoc/node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/typedoc/node_modules/yaml": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.0.tgz",
+      "integrity": "sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
       }
     },
     "node_modules/typescript": {
-      "version": "3.8.3",
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -10311,8 +10418,15 @@
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
+    },
+    "node_modules/uc.micro": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/uglify-es": {
       "version": "3.3.9",
@@ -10595,11 +10709,6 @@
       "integrity": "sha512-gQpnTgkubC6hQgdIcRdYGDSDc+SaujOdyesZQMv6JlfQee/9Mp0Qhnys6WxDWvQnL5WZdT7o2Ul187aSt0Rq+w==",
       "peer": true
     },
-    "node_modules/vscode-textmate": {
-      "version": "5.2.0",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/walker": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
@@ -10628,13 +10737,6 @@
       "peer": true,
       "dependencies": {
         "defaults": "^1.0.3"
-      }
-    },
-    "node_modules/webidl-conversions": {
-      "version": "5.0.0",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/webpack": {
@@ -10707,18 +10809,6 @@
         "webidl-conversions": "^3.0.0"
       }
     },
-    "node_modules/whatwg-url-without-unicode": {
-      "version": "8.0.0-3",
-      "license": "MIT",
-      "dependencies": {
-        "buffer": "^5.4.3",
-        "punycode": "^2.1.1",
-        "webidl-conversions": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/whatwg-url/node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
@@ -10771,7 +10861,8 @@
     },
     "node_modules/wrappy": {
       "version": "1.0.2",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/write-file-atomic": {
       "version": "2.4.3",
@@ -10838,11 +10929,6 @@
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
       "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
       "peer": true
-    },
-    "node_modules/yallist": {
-      "version": "3.1.1",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/yaml": {
       "version": "1.10.2",
@@ -12336,6 +12422,19 @@
       "version": "0.5.5",
       "dev": true
     },
+    "@gerrit0/mini-shiki": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@gerrit0/mini-shiki/-/mini-shiki-3.6.0.tgz",
+      "integrity": "sha512-KaeJvPNofTEZR9EzVNp/GQzbQqkGfjiu6k3CXKvhVTX+8OoAKSX/k7qxLKOX3B0yh2XqVAc93rsOu48CGt2Qug==",
+      "dev": true,
+      "requires": {
+        "@shikijs/engine-oniguruma": "^3.6.0",
+        "@shikijs/langs": "^3.6.0",
+        "@shikijs/themes": "^3.6.0",
+        "@shikijs/types": "^3.6.0",
+        "@shikijs/vscode-textmate": "^10.0.2"
+      }
+    },
     "@hapi/hoek": {
       "version": "9.3.0",
       "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
@@ -12654,6 +12753,50 @@
       "integrity": "sha512-K0aGNn1TjalKj+65D7ycc1//H9roAQ51GJVk5ZJQFb2teECGmzd86bYDC0aYdbRf7gtovescq4Zt6FR0tgXiHQ==",
       "peer": true
     },
+    "@shikijs/engine-oniguruma": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.6.0.tgz",
+      "integrity": "sha512-nmOhIZ9yT3Grd+2plmW/d8+vZ2pcQmo/UnVwXMUXAKTXdi+LK0S08Ancrz5tQQPkxvjBalpMW2aKvwXfelauvA==",
+      "dev": true,
+      "requires": {
+        "@shikijs/types": "3.6.0",
+        "@shikijs/vscode-textmate": "^10.0.2"
+      }
+    },
+    "@shikijs/langs": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.6.0.tgz",
+      "integrity": "sha512-IdZkQJaLBu1LCYCwkr30hNuSDfllOT8RWYVZK1tD2J03DkiagYKRxj/pDSl8Didml3xxuyzUjgtioInwEQM/TA==",
+      "dev": true,
+      "requires": {
+        "@shikijs/types": "3.6.0"
+      }
+    },
+    "@shikijs/themes": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.6.0.tgz",
+      "integrity": "sha512-Fq2j4nWr1DF4drvmhqKq8x5vVQ27VncF8XZMBuHuQMZvUSS3NBgpqfwz/FoGe36+W6PvniZ1yDlg2d4kmYDU6w==",
+      "dev": true,
+      "requires": {
+        "@shikijs/types": "3.6.0"
+      }
+    },
+    "@shikijs/types": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.6.0.tgz",
+      "integrity": "sha512-cLWFiToxYu0aAzJqhXTQsFiJRTFDAGl93IrMSBNaGSzs7ixkLfdG6pH11HipuWFGW5vyx4X47W8HDQ7eSrmBUg==",
+      "dev": true,
+      "requires": {
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      }
+    },
+    "@shikijs/vscode-textmate": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
+      "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
+      "dev": true
+    },
     "@sideway/address": {
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.4.tgz",
@@ -12898,6 +13041,15 @@
         "@types/node": "*"
       }
     },
+    "@types/hast": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "dev": true,
+      "requires": {
+        "@types/unist": "*"
+      }
+    },
     "@types/istanbul-lib-coverage": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.4.tgz",
@@ -12962,6 +13114,12 @@
     },
     "@types/semver": {
       "version": "7.3.9",
+      "dev": true
+    },
+    "@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
       "dev": true
     },
     "@types/webpack": {
@@ -13454,7 +13612,8 @@
       "version": "1.0.0"
     },
     "base64-js": {
-      "version": "1.5.1"
+      "version": "1.5.1",
+      "peer": true
     },
     "big-integer": {
       "version": "1.6.51",
@@ -13490,6 +13649,7 @@
     },
     "brace-expansion": {
       "version": "1.1.11",
+      "peer": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -13519,13 +13679,6 @@
       "peer": true,
       "requires": {
         "node-int64": "^0.4.0"
-      }
-    },
-    "buffer": {
-      "version": "5.7.1",
-      "requires": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.1.13"
       }
     },
     "buffer-from": {
@@ -13904,7 +14057,8 @@
       }
     },
     "concat-map": {
-      "version": "0.0.1"
+      "version": "0.0.1",
+      "peer": true
     },
     "connect": {
       "version": "3.7.0",
@@ -14693,7 +14847,8 @@
       }
     },
     "fs.realpath": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "peer": true
     },
     "fsevents": {
       "version": "2.3.2",
@@ -14745,6 +14900,7 @@
     },
     "glob": {
       "version": "7.2.0",
+      "peer": true,
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -14931,9 +15087,6 @@
       "dev": true,
       "requires": {}
     },
-    "ieee754": {
-      "version": "1.2.1"
-    },
     "ignore": {
       "version": "5.1.8",
       "dev": true
@@ -14962,13 +15115,15 @@
     },
     "inflight": {
       "version": "1.0.6",
+      "peer": true,
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
       }
     },
     "inherits": {
-      "version": "2.0.4"
+      "version": "2.0.4",
+      "peer": true
     },
     "invariant": {
       "version": "2.2.4",
@@ -15520,10 +15675,6 @@
       "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
       "peer": true
     },
-    "jsonc-parser": {
-      "version": "3.0.0",
-      "dev": true
-    },
     "jsonfile": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
@@ -15569,6 +15720,15 @@
     "lilconfig": {
       "version": "2.0.3",
       "dev": true
+    },
+    "linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+      "dev": true,
+      "requires": {
+        "uc.micro": "^2.0.0"
+      }
     },
     "loader-runner": {
       "version": "4.2.0",
@@ -15696,13 +15856,6 @@
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
     },
-    "lru-cache": {
-      "version": "5.1.1",
-      "dev": true,
-      "requires": {
-        "yallist": "^3.0.2"
-      }
-    },
     "lunr": {
       "version": "2.3.9",
       "dev": true
@@ -15749,9 +15902,33 @@
         "object-visit": "^1.0.0"
       }
     },
-    "marked": {
-      "version": "3.0.7",
-      "dev": true
+    "markdown-it": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.0.tgz",
+      "integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
+      "dev": true,
+      "requires": {
+        "argparse": "^2.0.1",
+        "entities": "^4.4.0",
+        "linkify-it": "^5.0.0",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
+      },
+      "dependencies": {
+        "argparse": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+          "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+          "dev": true
+        },
+        "entities": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+          "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+          "dev": true
+        }
+      }
     },
     "md5": {
       "version": "2.3.0",
@@ -15764,6 +15941,12 @@
     },
     "mdn-data": {
       "version": "2.0.14",
+      "dev": true
+    },
+    "mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
       "dev": true
     },
     "merge-options": {
@@ -16236,6 +16419,7 @@
     },
     "minimatch": {
       "version": "3.0.4",
+      "peer": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -16514,6 +16698,7 @@
     },
     "once": {
       "version": "1.4.0",
+      "peer": true,
       "requires": {
         "wrappy": "1"
       }
@@ -16525,13 +16710,6 @@
       "peer": true,
       "requires": {
         "mimic-fn": "^1.0.0"
-      }
-    },
-    "onigasm": {
-      "version": "2.2.5",
-      "dev": true,
-      "requires": {
-        "lru-cache": "^5.1.1"
       }
     },
     "open": {
@@ -16695,7 +16873,8 @@
       "peer": true
     },
     "path-is-absolute": {
-      "version": "1.0.1"
+      "version": "1.0.1",
+      "peer": true
     },
     "path-key": {
       "version": "2.0.1",
@@ -17153,7 +17332,14 @@
       }
     },
     "punycode": {
-      "version": "2.1.1"
+      "version": "2.1.1",
+      "dev": true
+    },
+    "punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
+      "dev": true
     },
     "queue-microtask": {
       "version": "1.2.3",
@@ -17255,12 +17441,6 @@
         "flow-parser": "^0.121.0",
         "jscodeshift": "^0.11.0",
         "nullthrows": "^1.1.1"
-      }
-    },
-    "react-native-url-polyfill": {
-      "version": "1.3.0",
-      "requires": {
-        "whatwg-url-without-unicode": "8.0.0-3"
       }
     },
     "react-refresh": {
@@ -17850,15 +18030,6 @@
         "array-map": "~0.0.0",
         "array-reduce": "~0.0.0",
         "jsonify": "~0.0.0"
-      }
-    },
-    "shiki": {
-      "version": "0.9.12",
-      "dev": true,
-      "requires": {
-        "jsonc-parser": "^3.0.0",
-        "onigasm": "^2.2.5",
-        "vscode-textmate": "5.2.0"
       }
     },
     "signal-exit": {
@@ -18507,18 +18678,54 @@
       "peer": true
     },
     "typedoc": {
-      "version": "0.22.6",
+      "version": "0.28.5",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.28.5.tgz",
+      "integrity": "sha512-5PzUddaA9FbaarUzIsEc4wNXCiO4Ot3bJNeMF2qKpYlTmM9TTaSHQ7162w756ERCkXER/+o2purRG6YOAv6EMA==",
       "dev": true,
       "requires": {
-        "glob": "^7.2.0",
+        "@gerrit0/mini-shiki": "^3.2.2",
         "lunr": "^2.3.9",
-        "marked": "^3.0.4",
-        "minimatch": "^3.0.4",
-        "shiki": "^0.9.11"
+        "markdown-it": "^14.1.0",
+        "minimatch": "^9.0.5",
+        "yaml": "^2.7.1"
+      },
+      "dependencies": {
+        "brace-expansion": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+          "dev": true,
+          "requires": {
+            "balanced-match": "^1.0.0"
+          }
+        },
+        "minimatch": {
+          "version": "9.0.5",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+          "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^2.0.1"
+          }
+        },
+        "yaml": {
+          "version": "2.8.0",
+          "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.0.tgz",
+          "integrity": "sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==",
+          "dev": true
+        }
       }
     },
     "typescript": {
-      "version": "3.8.3",
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "dev": true
+    },
+    "uc.micro": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
       "dev": true
     },
     "uglify-es": {
@@ -18724,10 +18931,6 @@
       "integrity": "sha512-gQpnTgkubC6hQgdIcRdYGDSDc+SaujOdyesZQMv6JlfQee/9Mp0Qhnys6WxDWvQnL5WZdT7o2Ul187aSt0Rq+w==",
       "peer": true
     },
-    "vscode-textmate": {
-      "version": "5.2.0",
-      "dev": true
-    },
     "walker": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
@@ -18753,9 +18956,6 @@
       "requires": {
         "defaults": "^1.0.3"
       }
-    },
-    "webidl-conversions": {
-      "version": "5.0.0"
     },
     "webpack": {
       "version": "5.61.0",
@@ -18815,14 +19015,6 @@
         }
       }
     },
-    "whatwg-url-without-unicode": {
-      "version": "8.0.0-3",
-      "requires": {
-        "buffer": "^5.4.3",
-        "punycode": "^2.1.1",
-        "webidl-conversions": "^5.0.0"
-      }
-    },
     "which": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
@@ -18861,7 +19053,8 @@
       }
     },
     "wrappy": {
-      "version": "1.0.2"
+      "version": "1.0.2",
+      "peer": true
     },
     "write-file-atomic": {
       "version": "2.4.3",
@@ -18919,10 +19112,6 @@
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
       "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
       "peer": true
-    },
-    "yallist": {
-      "version": "3.1.1",
-      "dev": true
     },
     "yaml": {
       "version": "1.10.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "supertokens-react-native",
-  "version": "5.1.4",
+  "version": "5.1.5",
   "description": "React Native SDK for SuperTokens",
   "main": "index.js",
   "scripts": {
@@ -44,12 +44,11 @@
     "axios": "*",
     "prettier": "1.18.2",
     "size-limit": "^6.0.4",
-    "typescript": "3.8.3",
-    "typedoc": "^0.22.5"
+    "typescript": "5.8.3",
+    "typedoc": "0.28.5"
   },
   "dependencies": {
     "base-64": "^1.0.0",
-    "react-native-url-polyfill": "^1.3.0",
     "supertokens-js-override": "^0.0.4"
   },
   "size-limit": [


### PR DESCRIPTION
## Summary of change
(A few sentences about this PR)

## Related issues
- Link to issue1 here
- Link to issue1 here

## Test Plan
(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Documentation changes
(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates
- [ ] Changelog has been updated
- [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
   - Along with the associated array in `lib/ts/version.ts`
- [ ] Changes to the version if needed
   - In `package.json`
   - In `package-lock.json`
   - In `lib/ts/version.ts`
- [ ] Had run `npm run build-pretty`
- [ ] Had installed and ran the pre-commit hook
- [ ] Issue this PR against the latest non released version branch.
   - To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
   - If no such branch exists, then create one from the latest released branch.

## Remaining TODOs for this PR
- [ ] Item1
- [ ] Item2